### PR TITLE
Save/restore cursor location on saving search state

### DIFF
--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -226,8 +226,8 @@ export default class SearchForm extends React.PureComponent {
     );
 
   handleSearchChange = ({ target }) => {
-    var cursorStart = target.selectionStart,
-      cursorEnd = target.selectionEnd;
+    const cursorStart = target.selectionStart;
+    const cursorEnd = target.selectionEnd;
 
     this.setQueryAs(target.value)()
       .then(() => target.setSelectionRange(cursorStart, cursorEnd))

--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -225,8 +225,12 @@ export default class SearchForm extends React.PureComponent {
       }))
     );
 
-  handleSearchChange = ({ target: { value } }) => {
-    this.setQueryAs(value)();
+  handleSearchChange = ({ target }) => {
+    var cursorStart = target.selectionStart,
+      cursorEnd = target.selectionEnd;
+
+    this.setQueryAs(target.value)()
+      .then(() => target.setSelectionRange(cursorStart, cursorEnd))
   };
 
   handleSearchSourceChange = e =>

--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -96,17 +96,21 @@ export default class SearchForm extends React.PureComponent {
     const tick = () =>
       (this.timer = setTimeout(
         () =>
-          this._setState(({ isAnimatingPlaceholder, placeholder }) => {
-            if (!isAnimatingPlaceholder) return null;
+          this._setState(
+            ({ isAnimatingPlaceholder, placeholder }) => {
+              if (!isAnimatingPlaceholder) return null;
 
-            if (placeholder === finalPlaceholder) {
-              return { isAnimatingPlaceholder: false };
-            } else if (finalPlaceholder[placeholder.length]) {
-              return {
-                placeholder: placeholder + finalPlaceholder[placeholder.length],
-              };
-            }
-          }, () => this.state.isAnimatingPlaceholder && tick()),
+              if (placeholder === finalPlaceholder) {
+                return { isAnimatingPlaceholder: false };
+              } else if (finalPlaceholder[placeholder.length]) {
+                return {
+                  placeholder:
+                    placeholder + finalPlaceholder[placeholder.length],
+                };
+              }
+            },
+            () => this.state.isAnimatingPlaceholder && tick()
+          ),
         2000 / finalPlaceholder.length
       ));
 
@@ -229,8 +233,9 @@ export default class SearchForm extends React.PureComponent {
     const cursorStart = target.selectionStart;
     const cursorEnd = target.selectionEnd;
 
-    this.setQueryAs(target.value)()
-      .then(() => target.setSelectionRange(cursorStart, cursorEnd))
+    this.setQueryAs(target.value)().then(() =>
+      target.setSelectionRange(cursorStart, cursorEnd)
+    );
   };
 
   handleSearchSourceChange = e =>


### PR DESCRIPTION
Fixes #485.
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check i. Like [x] this. (No spaces).

Fixes #485.