### PR TITLE
Fix #553 Search highlight issue

### DIFF
--- a/src/js/components/Larivaar/ImprovedLarivaar.tsx
+++ b/src/js/components/Larivaar/ImprovedLarivaar.tsx
@@ -10,6 +10,7 @@ export interface ILarivaarProps {
   enable?: boolean;
   unicode: boolean;
   children: string;
+  query: string;
 }
 
 function Larivaar(props: ILarivaarProps) {
@@ -20,11 +21,16 @@ function Larivaar(props: ILarivaarProps) {
     enable = true,
     children,
     unicode,
+    query,
   } = props;
 
   if (!enable) {
     return (
-      <HighlightedSearchResult startIndex={startIndex} endIndex={endIndex}>
+      <HighlightedSearchResult
+        startIndex={startIndex}
+        endIndex={endIndex}
+        query={query}
+      >
         {children}
       </HighlightedSearchResult>
     );
@@ -37,6 +43,8 @@ function Larivaar(props: ILarivaarProps) {
           return `${word} `;
         }
 
+        const highlight = word.includes(query) ? true : false;
+
         return (
           <LarivaarWord
             startIndex={startIndex}
@@ -46,6 +54,7 @@ function Larivaar(props: ILarivaarProps) {
             unicode={unicode}
             larivaarAssist={larivaarAssist}
             index={index}
+            highlight={highlight}
           />
         );
       })}

--- a/src/js/components/Larivaar/ImprovedLarivaar.tsx
+++ b/src/js/components/Larivaar/ImprovedLarivaar.tsx
@@ -43,7 +43,7 @@ function Larivaar(props: ILarivaarProps) {
           return `${word} `;
         }
 
-        const highlight = word.includes(query) ? true : false;
+        const highlight = word.includes(query);
 
         return (
           <LarivaarWord

--- a/src/js/components/Larivaar/Word.tsx
+++ b/src/js/components/Larivaar/Word.tsx
@@ -14,10 +14,19 @@ export interface ILarivaarWordProps {
   index: number;
   startIndex?: number;
   endIndex?: number;
+  highlight?: boolean;
 }
 
 function LarivaarWord(props: ILarivaarWordProps) {
-  const { startIndex, endIndex, word, unicode, larivaarAssist, index } = props;
+  const {
+    startIndex,
+    endIndex,
+    word,
+    unicode,
+    larivaarAssist,
+    index,
+    highlight,
+  } = props;
 
   const segments = unicode
     ? fixLarivaarUnicode(word)
@@ -34,7 +43,7 @@ function LarivaarWord(props: ILarivaarWordProps) {
           color =
             larivaarAssist && index % 2 === 1 ? LARIVAAR_ASSIST_COLOR : '';
         } else {
-          if (index >= startIndex && index < endIndex) {
+          if (highlight || (index >= startIndex && index < endIndex)) {
             akharClass = 'search-highlight-word';
           }
 

--- a/src/js/components/SearchResults/HighlightedResult.js
+++ b/src/js/components/SearchResults/HighlightedResult.js
@@ -6,11 +6,11 @@ export default class HighlightedSearchResult extends React.PureComponent {
     children: PropTypes.string,
     startIndex: PropTypes.number,
     endIndex: PropTypes.number,
+    query: PropTypes.string,
   };
 
   render() {
-    const { children, startIndex, endIndex } = this.props;
-
+    const { children, startIndex, endIndex, query } = this.props;
     if (children === null) {
       return null;
     }
@@ -19,7 +19,9 @@ export default class HighlightedSearchResult extends React.PureComponent {
       <span
         key={i}
         className={
-          i >= startIndex && i < endIndex ? 'search-highlight-word' : ''
+          (i >= startIndex && i < endIndex) || word.includes(query)
+            ? 'search-highlight-word'
+            : ''
         }
       >
         {` ${word} `}

--- a/src/js/components/SearchResults/Result.js
+++ b/src/js/components/SearchResults/Result.js
@@ -62,6 +62,7 @@ export default class SearchResult extends React.PureComponent {
                   unicode={unicode}
                   startIndex={highlightStartIndex}
                   endIndex={higlightEndIndex}
+                  query={q}
                 >
                   {shabad.gurbani.unicode}
                 </Larivaar>
@@ -73,6 +74,7 @@ export default class SearchResult extends React.PureComponent {
                   enable={larivaar}
                   startIndex={highlightStartIndex}
                   endIndex={higlightEndIndex}
+                  query={q}
                 >
                   {shabad.gurbani.gurmukhi}
                 </Larivaar>

--- a/src/js/util/index.js
+++ b/src/js/util/index.js
@@ -278,6 +278,12 @@ export const getHighlightIndices = (baani, query, type) => {
   let baaniWords = baani.split(' ');
 
   switch (type) {
+    case SEARCH_TYPES.ENGLISH_WORD: {
+      start = 0;
+      end = baani.length;
+      break;
+    }
+
     // TODO: This is obviously not the best way to handle it.
     case SEARCH_TYPES.ROMANIZED: {
       query = query

--- a/src/js/util/index.js
+++ b/src/js/util/index.js
@@ -278,12 +278,6 @@ export const getHighlightIndices = (baani, query, type) => {
   let baaniWords = baani.split(' ');
 
   switch (type) {
-    case SEARCH_TYPES.ENGLISH_WORD: {
-      start = 0;
-      end = baani.length;
-      break;
-    }
-
     // TODO: This is obviously not the best way to handle it.
     case SEARCH_TYPES.ROMANIZED: {
       query = query


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

Now it highlights the search query everywhere in the baani (Fixes issue #553)
![chrome-capture3](https://user-images.githubusercontent.com/1990932/56080239-d27c4c00-5e1b-11e9-8e1c-b064f7fdadc7.gif)

Currently if we search for full word in english translation, it doesn't highlight anything. This gives the feel that these are disabled links.
![Screenshot from 2019-04-13 18-34-18](https://user-images.githubusercontent.com/1990932/56080142-d3f94480-5e1a-11e9-9b24-4d4072259a07.png)

So, I changed it to highlight everything when someone searches in Full word translation(English) mode.
![Screenshot from 2019-04-13 18-33-53](https://user-images.githubusercontent.com/1990932/56080158-086d0080-5e1b-11e9-969a-eafeda8b12bd.png)

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).