### PR TITLE
Fixes embed view

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -3,14 +3,14 @@ Array.prototype.forEach.call(
   document.querySelectorAll('[data-sttm-id],[data-sttm-ang]'),
   function(node) {
     var attributes = node.dataset.sttmId
-      ? 'id=' + node.dataset.sttmId
-      : 'ang=' +
+      ? 'shabad?id=' + node.dataset.sttmId
+      : 'ang?ang=' +
         node.dataset.sttmAng +
         '&source=' +
         (node.dataset.sttmSource || 'G');
 
     node.innerHTML =
-      '<iframe src="https://sttm.co/embed?id=' +
+      '<iframe src="https://sttm.co/' +
       attributes +
       '"frameBorder="0" height="' +
       (node.dataset.sttmHeight || 500) +

--- a/src/js/components/ShabadContent/ShabadContent.js
+++ b/src/js/components/ShabadContent/ShabadContent.js
@@ -200,9 +200,13 @@ class Shabad extends React.PureComponent {
     ].join(' ');
 
     Promise.resolve(
-      `<div ${attrs}><a href="https://sttm.co/embed?id=${
-        info.id
-      }">SikhiToTheMax</a></div><script async src="https://sttm.co/embed.js"></script>`
+      `<div ${attrs}><a href="https://sttm.co/${
+        type === 'ang'
+          ? 'ang?ang=' + info.source.pageno + '&source=' + info.source.id
+          : 'shabad?id=' + info.id
+      }">SikhiToTheMax</a></div><script async src="${
+        window.location.origin
+      }/embed.js"></script>`
     )
       .then(copyToClipboard)
       .then(() => showToast(TEXTS.EMBED_COPIED))


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

Fixes issue #667 

It fixes the 404 error, but currently, we have the search bar and display/font options in an embedded view. 
Shouldn't we hide the search bar and display/font options in an embedded view?
And we can even make these options a part of the embed code. So that users can style and share an embedded link, which will open in the way they customized it.

![Screenshot from 2019-05-09 19-02-27](https://user-images.githubusercontent.com/1990932/57457361-03ba3180-728d-11e9-88bf-20b3575fc0d4.png)


<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).