### PR TITLE
Larivaar hover

### DIFF
--- a/src/js/components/Larivaar/Word.tsx
+++ b/src/js/components/Larivaar/Word.tsx
@@ -1,11 +1,6 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { fixLarivaarUnicode, fixLarivaarGurmukhiFont } from './util';
-import {
-  HIGHLIGHTED_SEARCH_COLOR,
-  LARIVAAR_ASSIST_COLOR,
-  NORMAL_SEARCH_COLOR,
-} from '@/constants';
 
 export interface ILarivaarWordProps {
   word: string;
@@ -35,22 +30,24 @@ function LarivaarWord(props: ILarivaarWordProps) {
   return (
     <>
       {segments.map((item, i) => {
-        let color;
-        let akharClass;
+        let akharClass = '';
+        let assistLarivaar;
+
+        if (index % 2 === 1) {
+          akharClass += 'larivaar-word';
+        }
 
         // If this isn't a search result
         if (!(startIndex !== undefined && endIndex !== undefined)) {
-          color =
-            larivaarAssist && index % 2 === 1 ? LARIVAAR_ASSIST_COLOR : '';
+          assistLarivaar = larivaarAssist && index % 2 === 1;
         } else {
           if (highlight || (index >= startIndex && index < endIndex)) {
-            akharClass = 'search-highlight-word';
+            akharClass += ' search-highlight-word';
           }
-
-          if (larivaarAssist && index % 2 === 1) {
-            color = LARIVAAR_ASSIST_COLOR;
-          }
+          assistLarivaar = larivaarAssist && index % 2 === 1;
         }
+
+        akharClass += assistLarivaar ? ' larivaar-assist-word' : '';
 
         const key = `${index}.${i}`;
 
@@ -65,7 +62,7 @@ function LarivaarWord(props: ILarivaarWordProps) {
         }
 
         return (
-          <span key={key} className={akharClass} style={{ color }}>
+          <span key={key} className={akharClass}>
             <span>
               {item}
               <wbr />

--- a/src/js/components/Larivaar/__tests__/__snapshots__/Larivaar.test.tsx.snap
+++ b/src/js/components/Larivaar/__tests__/__snapshots__/Larivaar.test.tsx.snap
@@ -17,31 +17,41 @@ exports[`<Larivaar /> renders children when disabled 1`] = `
 
 exports[`<Larivaar /> renders concatenated children when enabled 1`] = `
 <div>
-  <span>
+  <span
+    class=""
+  >
     <span>
       V
       <wbr />
     </span>
   </span>
-  <span>
+  <span
+    class=""
+  >
     <span>
       a
       <wbr />
     </span>
   </span>
-  <span>
+  <span
+    class=""
+  >
     <span>
       h
       <wbr />
     </span>
   </span>
-  <span>
+  <span
+    class="larivaar-word"
+  >
     <span>
       Gu
       <wbr />
     </span>
   </span>
-  <span>
+  <span
+    class="larivaar-word"
+  >
     <span>
       ru
       <wbr />
@@ -67,58 +77,32 @@ Object {
       </span>
     </div>
     <div>
-      <span>
+      <span
+        class=""
+      >
         <span>
           V
           <wbr />
         </span>
       </span>
-      <span>
+      <span
+        class=""
+      >
         <span>
           a
           <wbr />
         </span>
       </span>
-      <span>
-        <span>
-          h
-          <wbr />
-        </span>
-      </span>
-      <span>
-        <span>
-          Gu
-          <wbr />
-        </span>
-      </span>
-      <span>
-        <span>
-          ru
-          <wbr />
-        </span>
-      </span>
-    </div>
-    <div>
-      <span>
-        <span>
-          V
-          <wbr />
-        </span>
-      </span>
-      <span>
-        <span>
-          a
-          <wbr />
-        </span>
-      </span>
-      <span>
+      <span
+        class=""
+      >
         <span>
           h
           <wbr />
         </span>
       </span>
       <span
-        style="color: rgb(243, 156, 29);"
+        class="larivaar-word"
       >
         <span>
           Gu
@@ -126,7 +110,49 @@ Object {
         </span>
       </span>
       <span
-        style="color: rgb(243, 156, 29);"
+        class="larivaar-word"
+      >
+        <span>
+          ru
+          <wbr />
+        </span>
+      </span>
+    </div>
+    <div>
+      <span
+        class=""
+      >
+        <span>
+          V
+          <wbr />
+        </span>
+      </span>
+      <span
+        class=""
+      >
+        <span>
+          a
+          <wbr />
+        </span>
+      </span>
+      <span
+        class=""
+      >
+        <span>
+          h
+          <wbr />
+        </span>
+      </span>
+      <span
+        class="larivaar-word larivaar-assist-word"
+      >
+        <span>
+          Gu
+          <wbr />
+        </span>
+      </span>
+      <span
+        class="larivaar-word larivaar-assist-word"
       >
         <span>
           ru
@@ -136,26 +162,32 @@ Object {
     </div>
   </body>,
   "container": <div>
-    <span>
+    <span
+      class=""
+    >
       <span>
         V
         <wbr />
       </span>
     </span>
-    <span>
+    <span
+      class=""
+    >
       <span>
         a
         <wbr />
       </span>
     </span>
-    <span>
+    <span
+      class=""
+    >
       <span>
         h
         <wbr />
       </span>
     </span>
     <span
-      style="color: rgb(243, 156, 29);"
+      class="larivaar-word larivaar-assist-word"
     >
       <span>
         Gu
@@ -163,7 +195,7 @@ Object {
       </span>
     </span>
     <span
-      style="color: rgb(243, 156, 29);"
+      class="larivaar-word larivaar-assist-word"
     >
       <span>
         ru

--- a/src/scss/_results.scss
+++ b/src/scss/_results.scss
@@ -1,3 +1,7 @@
+.larivaar-assist-word {
+  color: #f39c1d;
+}
+
 .search-results {
   margin: 0.5rem 0;
 }
@@ -24,6 +28,10 @@
       }
     }
 
+    .larivaar-assist-word {
+      color: #f39c1d;
+    }
+
     .dark-mode & {
       color: $sttm-light-blue-60;
     }
@@ -42,6 +50,12 @@
   .meta a {
     color: grey;
     padding-right: 5px;
+  }
+}
+
+.larivaar:hover {
+  > .larivaar-word {
+    color: #f39c1d;
   }
 }
 


### PR DESCRIPTION
Assists larivaar on hover. Issue #63 

@saintsoldierx Currently, this happens by default, when larivaar is enabled. Adding another button for hover assist would congest our already filled settings panel. I was thinking to add it once we clean up the settings.

![uarlz-2j6th](https://user-images.githubusercontent.com/1990932/61200679-e6c43380-a6ff-11e9-9f75-bcfdd6ccb098.gif)
