### PR TITLE
Fixes validating search input.

### DIFF
--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -164,7 +164,7 @@ export default class SearchForm extends React.PureComponent {
 
     const [title, pattern] =
       typeInt === SEARCH_TYPES.ROMANIZED
-        ? ['Enter 2 words minimum.', '(\\w+\\W+){1,}\\w+\\W*']
+        ? ['Enter 4 words minimum.', '(\\w+\\W+){3,}\\w+\\W*']
         : typeInt === SEARCH_TYPES.ANG
           ? ['Enter numbers only.', '\\d+']
           : ['Enter 2 characters minimum.', '.{2,}'];

--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -160,10 +160,12 @@ export default class SearchForm extends React.PureComponent {
 
     const className = useEnglish ? '' : 'gurbani-font';
 
+    const typeInt = parseInt(this.state.type);
+
     const [title, pattern] =
-      this.state.type === SEARCH_TYPES.ROMANIZED
+      typeInt === SEARCH_TYPES.ROMANIZED
         ? ['Enter 2 words minimum.', '(\\w+\\W+){1,}\\w+\\W*']
-        : this.state.type === SEARCH_TYPES.ANG
+        : typeInt === SEARCH_TYPES.ANG
           ? ['Enter numbers only.', '\\d+']
           : ['Enter 2 characters minimum.', '.{2,}'];
 

--- a/src/js/components/SearchResults/SearchResults.js
+++ b/src/js/components/SearchResults/SearchResults.js
@@ -25,7 +25,7 @@ export default class SearchResults extends React.PureComponent {
       <ul className="search-results display">
         {shabads.map(shabad => {
           return (
-            <SearchResult key={shabad.shabadId} shabad={shabad} {...props} />
+            <SearchResult key={shabad.verseId} shabad={shabad} {...props} />
           );
         })}
       </ul>


### PR DESCRIPTION
Currently, we can search with a single word in a romanized search (from the search page). 

This fixes the bug in setting up the pattern to have at least two words.

Fixes Issue #459 