### PR TITLE
Fixes scroll issue in autocomplete suggestions

### DIFF
--- a/src/js/components/Autocomplete.js
+++ b/src/js/components/Autocomplete.js
@@ -43,7 +43,7 @@ class Autocomplete extends Component {
       if (activeSuggestion + 1 < filteredSuggestions.length) {
         this.setState({ activeSuggestion: activeSuggestion + 1 });
         const newScroll = document.querySelector('.suggestion-active').offsetHeight;
-        document.getElementById('suggestions').scrollBy(0, newScroll);
+        activeSuggestion + 1 !== 0 && document.getElementById('suggestions').scrollBy(0, newScroll);
       }
     }
   };


### PR DESCRIPTION
Currently, the suggestion hides if we scroll down using an arrow key.

![chrome-capture (3)](https://user-images.githubusercontent.com/1990932/71067176-1937f800-219a-11ea-98fe-fd2b3096c4a5.gif)

This PR fixes the above issue.