### PR TITLE
Disables larivaar assist on hover when vishraams are enabled

### DIFF
--- a/src/scss/_results.scss
+++ b/src/scss/_results.scss
@@ -56,6 +56,10 @@
 .larivaar:hover {
   .larivaar-word {
     color: #f39c1d;
+
+    .display-visraams & {
+      color: initial;
+    }
   }
 }
 


### PR DESCRIPTION
Currently, pankti changed color to orange on hover, even when Vishraams were enabled.

This PR fixes that.