### PR TITLE
Translation transliteration fontsize

### DIFF
--- a/src/js/components/Baani.js
+++ b/src/js/components/Baani.js
@@ -167,7 +167,7 @@ export default class Baani extends React.PureComponent {
     );
 
     const getTransliterations = shabad => transliterationLanguages.map(language => (
-      <Transliteration key={getVerseId(shabad) + language}>
+      <Transliteration fontSize={fontSize} key={getVerseId(shabad) + language}>
         {transliterationMap[language](shabad)}
       </Transliteration>
     ));
@@ -183,6 +183,7 @@ export default class Baani extends React.PureComponent {
 
     const getTranslations = shabad => translationLanguages.map(language => (
       <Translation
+        fontSize={fontSize}
         key={getVerseId(shabad) + language}
         type={language}
         {...Translation.getTranslationProps({
@@ -259,7 +260,7 @@ export default class Baani extends React.PureComponent {
         {transliterationLanguages.map(language => (
           <div key={language} className="split-view-baani-wrapper">
             {gurbani.map(shabad => (
-              <Transliteration key={getVerseId(shabad)}>
+              <Transliteration fontSize={fontSize} key={getVerseId(shabad)}>
                 {transliterationMap[language](shabad)}
               </Transliteration>
             ))}
@@ -269,6 +270,7 @@ export default class Baani extends React.PureComponent {
           <div key={language} className="split-view-baani-wrapper">
             {gurbani.map(shabad => (
               <Translation
+                fontSize={fontSize}
                 key={getVerseId(shabad)}
                 type={language}
                 {...Translation.getTranslationProps({

--- a/src/js/components/Translation.js
+++ b/src/js/components/Translation.js
@@ -29,6 +29,10 @@ export default class Translation extends React.PureComponent {
         );
       }
     },
+    fontSize: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
     children: PropTypes.string,
   };
 
@@ -43,21 +47,23 @@ export default class Translation extends React.PureComponent {
       : { children: translationMap[language](shabad) };
 
   render() {
-    const { type, unicode, text } = this.props;
+    const defaultFontSize = '18px';
+    const { type, unicode, text, fontSize: _fontSize } = this.props;
+    const fontSize = _fontSize ? (0.7 * _fontSize) + 'em' : defaultFontSize;
 
     if (type === PUNJABI) {
       return (
-        <blockquote className="translation punjabi gurbani-font">
+        <blockquote style={{ fontSize }} className="translation punjabi gurbani-font">
           {unicode ? (
             <div className="unicode">{text.unicode}</div>
           ) : (
-            <div className="gurlipi">{text.gurmukhi}</div>
-          )}
+              <div className="gurlipi">{text.gurmukhi}</div>
+            )}
         </blockquote>
       );
     } else {
       return (
-        <blockquote className={`translation ${type}`}>
+        <blockquote style={{ fontSize }} className={`translation ${type}`}>
           {this.props.children}
         </blockquote>
       );

--- a/src/js/components/Transliteration.js
+++ b/src/js/components/Transliteration.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default class EnglishTransliteration extends React.PureComponent {
+export default class Transliteration extends React.PureComponent {
   static propTypes = {
     language: PropTypes.string,
     children: PropTypes.string.isRequired,
+    fontSize: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
   };
-
   render() {
+    const defaultFontSize = '18px';
+    const { fontSize: _fontSize } = this.props;
+    const fontSize = _fontSize ? (0.7 * _fontSize) + 'em' : defaultFontSize;
+
     return (
-      <div className={'transliteration ' + this.props.language}>
+      <div
+        style={{ fontSize }}
+        className={'transliteration ' + this.props.language}>
         {this.props.children}
       </div>
     );

--- a/src/scss/_shabad-page.scss
+++ b/src/scss/_shabad-page.scss
@@ -315,9 +315,9 @@ blockquote {
 
   &Title {
     font-size: 1.6em;
+    font-weight: 400;
     line-height: 1.2;
     margin-bottom: 0;
-    font-weight: 400;
   }
 
   &Transliteration,

--- a/src/scss/_shabad-page.scss
+++ b/src/scss/_shabad-page.scss
@@ -317,10 +317,7 @@ blockquote {
     font-size: 1.6em;
     line-height: 1.2;
     margin-bottom: 0;
-
-    @media screen and (max-width: 800px) {
-      font-weight: 400;
-    }
+    font-weight: 400;
   }
 
   &Transliteration,


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

Sizes for translation and transliteration are being controlled now with fontsize

![image](https://user-images.githubusercontent.com/8514802/83676629-9ea04f00-a5f8-11ea-91af-42cec0ffbfe7.png)


<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).