### PR TITLE
fixes the search results after changing search type

### DIFF
--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -263,18 +263,21 @@ export default class SearchForm extends React.PureComponent {
       }
     );
 
-  handleSearchTypeChange = ({ currentTarget: { value } }) =>
+  handleSearchTypeChange = ({ currentTarget: { value } }) => {
+
+    const isSearchTypeToAngType = this.state.type !== SEARCH_TYPES['ANG'] && Number(value) === SEARCH_TYPES['ANG'];
+
     this.stopPlaceholderAnimation().then(() =>
       this.setState(
         {
           type: parseInt(value, 10),
           source: parseInt(value, 10) === SEARCH_TYPES['ANG'] &&
-            !Object.keys(SOURCES_WITH_ANG).includes(this.state.source) ?
-            'G' : this.state.source,
-          query: this.state.query,
-          shouldSubmit:
+            Object.keys(SOURCES_WITH_ANG).includes(this.state.source) ?
+            this.state.source : 'G',
+          query: isSearchTypeToAngType ? '' : this.state.query,
+          shouldSubmit: isSearchTypeToAngType ? false :
             this.props.submitOnChangeOf.includes('type') &&
-            this.state.query !== '',
+            this.state.query !== ''
         },
         () => {
           clickEvent({ action: ACTIONS.SEARCH_TYPE, label: this.state.type });
@@ -290,6 +293,7 @@ export default class SearchForm extends React.PureComponent {
         }
       )
     );
+  }
 
   handleSubmit = () => {
     /* Possible Validations, Analytics */


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).