### PR TITLE
resolves steek-languages render redux storage issue - #1283

### DIFF
--- a/src/js/features/reducers/index.js
+++ b/src/js/features/reducers/index.js
@@ -372,16 +372,16 @@ export default function reducer(state, action) {
       };
     }
     case SET_TRANSLATION_LANGUAGES: {
-      const isPunjabiIncluded = action.payload.includes('punjabi');
+      const isPunjabiLanguageSelected = action.payload.includes('punjabi');
       const translationLanguages = action.payload || [];
       const isSteekLanguageSelected = state.steekLanguages.length > 0;
       let steekLanguages = [];
-      if (isPunjabiIncluded) {
+      if (isPunjabiLanguageSelected) {
         if (isSteekLanguageSelected)
           steekLanguages = state.steekLanguages;
         else {
-          const storedSteekLanguages = getArrayFromLocalStorage(LOCAL_STORAGE_KEY_FOR_STEEK_LANGUAGES);
-          steekLanguages = storedSteekLanguages.length > 0 ? storedSteekLanguages : ['bani db'];
+          // const storedSteekLanguages = getArrayFromLocalStorage(LOCAL_STORAGE_KEY_FOR_STEEK_LANGUAGES);
+          steekLanguages = ['bani db'];
         }
       }
 
@@ -410,29 +410,33 @@ export default function reducer(state, action) {
 
     case SET_STEEK_LANGUAGES: {
       const steekLanguages = action.payload || [];
+
+      let translationLanguages = []
+      if (steekLanguages.length > 0) {
+        const isPunjabiLanguageSelected = state.translationLanguages.includes(t => t === 'punjabi');
+        translationLanguages = isPunjabiLanguageSelected ? state.translationLanguages : [...state.translationLanguages, 'punjabi'];
+      } else {
+        translationLanguages = state.translationLanguages.filter(t => t !== 'punjabi');
+      }
+
       clickEvent({
         action: SET_STEEK_LANGUAGES,
         label: JSON.stringify(steekLanguages),
       });
 
-      if (steekLanguages.length > 0) {
-        saveToLocalStorage(
-          LOCAL_STORAGE_KEY_FOR_STEEK_LANGUAGES,
-          JSON.stringify(steekLanguages)
-        );
-        const isPunjabiTranslationIncluded = state.translationLanguages.includes(t => t === 'punjabi');
-        const translationLanguages = isPunjabiTranslationIncluded ? state.translationLanguages : [...state.translationLanguages, 'punjabi'];
+      saveToLocalStorage(
+        LOCAL_STORAGE_KEY_FOR_TRANSLATION_LANGUAGES,
+        JSON.stringify(translationLanguages)
+      );
 
-        return {
-          ...state,
-          steekLanguages,
-          translationLanguages
-        };
-      }
+      saveToLocalStorage(
+        LOCAL_STORAGE_KEY_FOR_STEEK_LANGUAGES,
+        JSON.stringify(steekLanguages)
+      );
 
       return {
         ...state,
-        translationLanguages: state.translationLanguages.filter(t => t !== 'punjabi'),
+        translationLanguages,
         steekLanguages
       }
 


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

Fixes issue related to storage of the steek-languages and punjabi translation settings.
<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).