### PR TITLE
Make top navigation accessibility fix

### DIFF
--- a/src/js/components/HeaderMenu.js
+++ b/src/js/components/HeaderMenu.js
@@ -1,91 +1,126 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import BarsIcon from './Icons/Bars';
 import BackIcon from './Icons/Back';
 
-/**
- *
- *
- * @class Menu
- * @extends {React.PureComponent}
- */
-export default class Menu extends React.PureComponent {
-  static propTypes = {
-    isHome: PropTypes.bool
-  };
+const Menu = ({ isHome }) => {
+  const displayAreaRef = useRef(null)
+  const dropTogglerRef = useRef(null)
 
-  toggleMenu = () => document.body.classList.toggle('menu-open');
-  closeMenu = () => document.body.classList.remove('menu-open');
-  goBack = () => window.history.back();
-  render() {
-    const { toggleMenu, closeMenu, goBack } = this;
-    return (
-      <React.Fragment>
-        {!this.props.isHome && (
-          <div className="top-bar-left">
-            <span
-              role="button"
-              aria-label="Open menu"
-              className="button"
-              id="open-mobile-menu"
-              onClick={goBack}
-            >
-              <BackIcon />
-            </span>
-          </div>
-        )}
-        <div className="top-bar-right">
+  const [toggleDropdown, setToggleDropdown] = useState(false);
+
+  useEffect(() => {
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    }
+  }, [])
+
+  function handleClickOutside(event) {
+    const path = event.path || (event.composedPath && event.composedPath());
+
+    if (
+      !path.includes(displayAreaRef.current) &&
+      !path.includes(dropTogglerRef.current)
+    ) {
+      setToggleDropdown(false);
+    }
+  }
+
+  function toggleMenu() {
+    /* TODO: This should be derived through useRef */
+    document.body.classList.toggle('menu-open');
+  }
+
+  function closeMenu() {
+    /* Same for this, please use useRef hook in order to access menu */
+    document.body.classList.remove('menu-open');
+  }
+
+  function goBack() {
+    window.history.back();
+  }
+
+  function toggleDropdownHandler() {
+    setToggleDropdown(!toggleDropdown)
+  }
+
+  return (
+    <React.Fragment>
+      {!isHome && (
+        <div className="top-bar-left">
           <span
             role="button"
             aria-label="Open menu"
             className="button"
             id="open-mobile-menu"
-            onClick={toggleMenu}
+            onClick={goBack}
           >
-            <BarsIcon />
+            <BackIcon />
           </span>
-          <ul className="menu header-menu">
-            <li>
-              <Link to="/hukamnama" onClick={toggleMenu}>
-                Hukamnama
-            </Link>
-            </li>
-            <li data-cy="random-shabad">
-              <Link to="/shabad?random" onClick={toggleMenu}>
-                Random Shabad
-              </Link>
-            </li>
-            <li data-cy="sundar-gutka-page">
-              <Link to="/sundar-gutka" onClick={toggleMenu}>
-                Sundar Gutka
-              </Link>
-            </li>
-            <li data-cy="index">
-              <Link to="/index" onClick={toggleMenu}>
-                Index
-              </Link>
-            </li>
-            <li data-cy="sync" className="submenu">
-              <p>Sync
-              <BackIcon /></p>
-              <div className="submenu-items">
-                <Link to="/sync" onClick={toggleMenu}>
-                  Sangat Sync
-                </Link>
-                <Link to="/control" onClick={toggleMenu}>
-                  Bani Controller
-                </Link>
-              </div>
-            </li>
-            <li className="close">
-              <span role="button" aria-label="Close menu" onClick={closeMenu}>
-                Close
-              </span>
-            </li>
-          </ul>
         </div>
-      </React.Fragment>
-    );
-  }
+      )}
+      <div className="top-bar-right">
+        <span
+          role="button"
+          aria-label="Open menu"
+          className="button"
+          id="open-mobile-menu"
+          onClick={toggleMenu}
+        >
+          <BarsIcon />
+        </span>
+        <ul className="menu header-menu">
+          <li>
+            <Link to="/hukamnama" onClick={toggleMenu}>
+              Hukamnama
+              </Link>
+          </li>
+          <li data-cy="random-shabad">
+            <Link to="/shabad?random" onClick={toggleMenu}>
+              Random Shabad
+              </Link>
+          </li>
+          <li data-cy="sundar-gutka-page">
+            <Link to="/sundar-gutka" onClick={toggleMenu}>
+              Sundar Gutka
+              </Link>
+          </li>
+          <li data-cy="index">
+            <Link to="/index" onClick={toggleMenu}>
+              Index
+              </Link>
+          </li>
+          <li data-cy="sync" className={`${toggleDropdown ? 'opened' : ''} submenu`}>
+            <button name="sync-btn" onClick={toggleDropdownHandler} ref={dropTogglerRef}>
+              <span>
+                Sync
+                <BackIcon />
+              </span>
+            </button>
+            <div className="submenu-items" ref={displayAreaRef}>
+              <Link to="/sync" onClick={toggleMenu}>
+                Sangat Sync
+                </Link>
+              <Link to="/control" onClick={toggleMenu}>
+                Bani Controller
+                </Link>
+            </div>
+          </li>
+          <li className="close">
+            <span role="button" aria-label="Close menu" onClick={closeMenu}>
+              Close
+              </span>
+          </li>
+        </ul>
+      </div>
+    </React.Fragment>
+  );
 }
+
+Menu.propTypes = {
+  isHome: PropTypes.bool
+};
+
+export default Menu;

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -96,6 +96,15 @@
   }
 }
 
+.submenu {
+  svg {
+    fill: $sttm-dark-grey;
+    padding-top: 5px;
+    transform: rotate(-90deg);
+    vertical-align: middle;
+  }
+}
+
 .top-bar-right .menu > li {
   display: inline-block;
   font-weight: 400;
@@ -105,17 +114,6 @@
     z-index: 10;
 
     p {
-      display: inline-block;
-    }
-
-    svg {
-      fill: $sttm-dark-grey;
-      padding-top: 5px;
-      transform: rotate(-90deg);
-      vertical-align: middle;
-    }
-
-    &:hover > .submenu-items {
       display: inline-block;
     }
   }
@@ -505,7 +503,7 @@
         width: 100%;
       }
 
-      p {
+      button {
         display: none;
       }
     }
@@ -579,7 +577,6 @@
     .submenu > .submenu-items {
       background-color: $sttm-white;
       border: 1px solid $sttm-lighter-grey;
-      display: none;
       position: absolute;
       right: 0;
       top: 44px;
@@ -608,6 +605,24 @@
   #open-mobile-menu,
   .top-bar-right .menu .close {
     display: none;
+  }
+
+  .submenu {
+    .submenu-items {
+      display: none;
+    }
+
+    &.opened {
+      .submenu-items {
+        display: inline-block;
+      }
+
+      svg {
+        padding-bottom: 5px;
+        padding-top: 0;
+        transform: rotate(90deg);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Instead of hover on Sync text, you have to click on it to reach to dropdown links

https://github.com/KhalisFoundation/sttm-web/issues/1389

1. "Sync" text is now <button /> on which you can click and see menu items under it.
2. For better performance, I changed component type from stateful to stateless (functional component).

Please use both the keyboard and mouse to test this feature.

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).