### PR TITLE
Add khakha with bindi to virtual keyboard

### DIFF
--- a/src/js/components/EnhancedGurmukhiKeyboard/constants.js
+++ b/src/js/components/EnhancedGurmukhiKeyboard/constants.js
@@ -2,7 +2,7 @@ export const withoutMatra = [
   ['a', 'A', 'e', 's', 'h', 'k', 'K', 'g', 'G', '|'],
   ['c', 'C', 'j', 'J', '\\', 't', 'T', 'f', 'F', 'x'],
   ['q', 'Q', 'd', 'D', 'n', 'p', 'P', 'b', 'B', 'm'],
-  ['X', 'r', 'l', 'v', 'V', 'space', 'meta'],
+  ['X', 'r', 'l', 'v', 'V', '^', 'space', 'meta'],
 ];
 
 export const withMatra = [


### PR DESCRIPTION
The option has been added to the regular keyboard as well.
Now users can select Khaka with bindi from the virtual keyboard too.

![Screencast 2021-04-17 at 22 48 - SikhiToTheMax](https://user-images.githubusercontent.com/3865313/115126477-89919c00-9fcf-11eb-89b1-c1c2afb23c95.gif)

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [ ] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [ ] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [ ] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).