### PR TITLE
add exception to skip ctrl/command(mac)+l key combination in hotkeys

### DIFF
--- a/src/js/Shortcuts.js
+++ b/src/js/Shortcuts.js
@@ -65,8 +65,16 @@ const GlobalHandlers = {
   }
 }
 const ViewerShortcutHanders = {
-  toggleLarivar: () => {
-    store.dispatch({ type: "TOGGLE_LARIVAAR_OPTION" })
+  toggleLarivar: (event) => {
+    /*
+      NOTE:
+      added exception to handle Ctrl/command(mac)+l key combination.
+      it shouldn't toggle Larivaar with Ctrl/command(mac)+l combination.
+    */
+    const isMeta = event?.metaKey;
+    if (!isMeta) {
+      store.dispatch({ type: "TOGGLE_LARIVAAR_OPTION" })
+    }
   },
   toggleLarivarAssist: () => {
     store.dispatch({ type: 'TOGGLE_LARIVAAR_ASSIST_OPTION', })


### PR DESCRIPTION
Please use your keyboard and try command+l or ctrl+l (windows).
Control shouldn't switch you to larivaar version.
Now try only "l" key from your keyboard and you can toggle between larivaar version.

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).