### PR TITLE
Feature/1400 accessibility enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,6 +1943,26 @@
         }
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.5.tgz",
+      "integrity": "sha512-dD1FRHuWhfdcnb6H9/oaIIZHx9LQKGxbTtYV3i5Zru8I3GWWJoG2WtlAlXZ/56djO+6TvfsWPj5cXQvoTFQATQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/preset-typescript": "^7.10.1",
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.2.1",
+    "@testing-library/user-event": "^13.1.5",
     "@types/jest": "^23.3.14",
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",

--- a/src/js/components/GurmukhiKeyboardToggleButton.js
+++ b/src/js/components/GurmukhiKeyboardToggleButton.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import KeyboardIcon from './Icons/Keyboard';
+import { TEXTS } from '@/constants';
+
+const GurmukhiKeyboardToggleButton = ({clickHandler, isVisible}) => {
+  return <button
+    type="button"
+    aria-label={TEXTS.TOGGLE_GURMUKHI_KEYBOARD}
+    className={`gurmukhi-keyboard-toggle ${
+      isVisible ? 'active' : ''
+      }`}
+    onClick={clickHandler(!isVisible)}
+  >
+    <KeyboardIcon />
+  </button>
+}
+
+export default GurmukhiKeyboardToggleButton;

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -8,10 +8,10 @@ import { EnhancedGurmukhiKeyboard } from './EnhancedGurmukhiKeyboard';
 import SearchForm from './SearchForm';
 import CrossIcon from './Icons/Times';
 import Menu from './HeaderMenu';
-import KeyboardIcon from './Icons/Keyboard';
 import SearchIcon from './Icons/Search';
 import Reset from './Icons/Reset';
 import Autocomplete from '@/components/Autocomplete';
+import GurmukhiKeyboardToggleButton from '@/components/GurmukhiKeyboardToggleButton';
 import { toggleSettingsPanel } from '@/features/actions';
 
 import {
@@ -228,19 +228,7 @@ class Header extends React.PureComponent {
                                       <CrossIcon />
                                     </button>
 
-                                    {isShowKeyboard && (
-                                      <button
-                                        type="button"
-                                        className={`gurmukhi-keyboard-toggle ${
-                                          displayGurmukhiKeyboard ? 'active' : ''
-                                          }`}
-                                        onClick={setGurmukhiKeyboardVisibilityAs(
-                                          !displayGurmukhiKeyboard
-                                        )}
-                                      >
-                                        <KeyboardIcon />
-                                      </button>
-                                    )}
+                                    {isShowKeyboard && <GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />}
 
                                     <button
                                       type="submit" disabled={disabled}>

--- a/src/js/components/__tests__/GurmukhiKeyboardToggleButton.js
+++ b/src/js/components/__tests__/GurmukhiKeyboardToggleButton.js
@@ -1,0 +1,57 @@
+/* global describe, it, expect, jest */
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import GurmukhiKeyboardToggleButton from '../GurmukhiKeyboardToggleButton';
+import { StaticRouter } from 'react-router-dom';
+
+describe('<GurmukhiKeyboardToggleButton />', () => {
+  const clickFn = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should have active class isVisible is true', () => {
+    const { container } = render(
+      <StaticRouter context={{}}>
+        <GurmukhiKeyboardToggleButton
+          clickHandler={clickFn}
+          isVisible
+        />
+      </StaticRouter>
+    );
+
+    expect(container.querySelector('.gurmukhi-keyboard-toggle.active')).toBeInTheDocument();
+  });
+
+  it('shouldn\'t have active class isVisible is false', () => {
+    const { container } = render(
+      <StaticRouter context={{}}>
+        <GurmukhiKeyboardToggleButton
+          clickHandler={clickFn}
+        />
+      </StaticRouter>
+    );
+
+    expect(container.querySelector('.gurmukhi-keyboard-toggle.active')).not.toBeInTheDocument();
+  });
+
+  it('should trigger click handler', () => {
+    const { container } = render(
+      <StaticRouter context={{}}>
+        <GurmukhiKeyboardToggleButton
+          clickHandler={clickFn}
+          isVisible
+        />
+      </StaticRouter>
+    );
+
+    const element = container.querySelector('.gurmukhi-keyboard-toggle');
+
+    userEvent.click(element);
+
+    expect(clickFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/js/constants/texts.ts
+++ b/src/js/constants/texts.ts
@@ -86,4 +86,5 @@ export const TEXTS = {
   CENTERALIGN: 'Center-Align',
   HUKAMNAMA_NOT_FOUND_DESCRIPTION:
     "We couldn't find the hukamnama for this date in our database.",
+  TOGGLE_GURMUKHI_KEYBOARD: "toggle gurmukhi keyboard",
 };

--- a/src/js/pages/Home/index.js
+++ b/src/js/pages/Home/index.js
@@ -13,10 +13,10 @@ import { BaaniLinks } from '@/components/BaaniLinks/';
 import SearchForm from '@/components/SearchForm';
 import Logo from '@/components/Icons/Logo';
 import CrossIcon from '@/components/Icons/Times';
-import KeyboardIcon from '@/components/Icons/Keyboard';
 import SearchIcon from '@/components/Icons/Search';
 import Autocomplete from '@/components/Autocomplete';
 import Reset from '@/components/Icons/Reset';
+import GurmukhiKeyboardToggleButton from '@/components/GurmukhiKeyboardToggleButton';
 /**
  *
  *
@@ -143,19 +143,7 @@ export default class Home extends React.PureComponent {
                       >
                         <CrossIcon />
                       </button>
-                      {isShowKeyboard && (
-                        <button
-                          type="button"
-                          className={`gurmukhi-keyboard-toggle ${
-                            displayGurmukhiKeyboard ? 'active' : ''
-                            }`}
-                          onClick={setGurmukhiKeyboardVisibilityAs(
-                            !displayGurmukhiKeyboard
-                          )}
-                        >
-                          <KeyboardIcon />
-                        </button>
-                      )}
+                      {isShowKeyboard && <GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />}
                       <button type="submit" disabled={disabled}>
                         <SearchIcon />
                       </button>

--- a/src/js/pages/WebController/search-input.js
+++ b/src/js/pages/WebController/search-input.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CrossIcon from '../../components/Icons/Times';
-import KeyboardIcon from '../../components/Icons/Keyboard';
 import SearchIcon from '../../components/Icons/Search';
 import { EnhancedGurmukhiKeyboard } from '../../components/EnhancedGurmukhiKeyboard';
+import GurmukhiKeyboardToggleButton from '../../components/GurmukhiKeyboardToggleButton';
 import SearchForm from '../../components/SearchForm';
 
 import {
@@ -107,19 +107,9 @@ export default class SearchInput extends React.PureComponent {
                       >
                         <CrossIcon />
                       </button>
-                      {type > 2 ? '' : (
-                        <button
-                          type="button"
-                          className={`gurmukhi-keyboard-toggle ${
-                            displayGurmukhiKeyboard ? 'active' : ''
-                            }`}
-                          onClick={setGurmukhiKeyboardVisibilityAs(
-                            !displayGurmukhiKeyboard
-                          )}
-                        >
-                          <KeyboardIcon />
-                        </button>
-                      )}
+                      
+                      {type > 2 ? '' : (<GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />)}
+                      
                       <button type="submit">
                         <SearchIcon />
                       </button>

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -219,8 +219,9 @@
       fill: $sttm-orange;
     }
 
-    &:active svg,
-    &:hover svg {
+    &:hover svg,
+    &:focus svg,
+    &:active svg {
       fill: $sttm-orange;
       outline: none;
     }


### PR DESCRIPTION
https://github.com/KhalisFoundation/sttm-web/issues/1400

- Add focus state to the keyboard toggle button, for better accessibility.
- Add `aria-label` on keyboard togle button for screen readers.
- Add reusable button for keyboard toggle, with test cases.

### Focus State
![image](https://user-images.githubusercontent.com/3865313/115909094-50dc4180-a46b-11eb-8926-e958a0cf739c.png)

### Aria-label from screen reader's perspective
![image](https://user-images.githubusercontent.com/3865313/115909186-71a49700-a46b-11eb-860f-c08280aba226.png)

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).