### PR TITLE
Feature/1400 accessibility enhancements 2

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -3,6 +3,8 @@ const API_URLS_CONSTANTS = require('./api-urls-constants');
 const isProduction = process.env.NODE_ENV === 'production';
 export const DARK_MODE_COOKIE = 'darkmode';
 export const DARK_MODE_CLASS_NAME = 'dark-mode';
+export const LANGUAGE_COOKIE = 'lang';
+export const DEFAULT_LANGUAGE = 'en';
 
 export const ONLINE_COLOR = '#01669b';
 export const OFFLINE_COLOR = '#333333';

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ import cookieParser from 'cookie-parser';
 import { hostname as _hostname } from 'os';
 import createTemplate from './template';
 import seo from '../common/seo';
-import { DARK_MODE_COOKIE, DARK_MODE_CLASS_NAME } from '../common/constants';
+import { DARK_MODE_COOKIE, DARK_MODE_CLASS_NAME, LANGUAGE_COOKIE, DEFAULT_LANGUAGE } from '../common/constants';
 import { getMetadataFromRequest, createMetadataFromResponse } from './utils/';
 
 const hostname = _hostname().substr(0, 3);
@@ -36,6 +36,8 @@ app
   .get('*', async (req, res) => {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
 
+    const language = req.cookies[LANGUAGE_COOKIE] || DEFAULT_LANGUAGE;
+
     const { path, url } = req;
 
     const { createTitle, createDescription } = seo[
@@ -65,6 +67,7 @@ app
         bodyClass,
         title,
         description,
+        language,
       });
 
       template(res, { debug: 'off', stringToBufferThreshold: 1000 });

--- a/server/template.js
+++ b/server/template.js
@@ -19,9 +19,9 @@ try {
 <html lang="en">
 TODO: language attribute is hard coded for now, make it dynamic when actual language support is added.
 */
-export default ({ url, bodyClass, title, description }) => marinate`
+export default ({ url, bodyClass, title, description, language }) => marinate`
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${language}">
 <head>
   <title>${title}</title>
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />

--- a/server/template.js
+++ b/server/template.js
@@ -17,7 +17,7 @@ try {
 
 export default ({ url, bodyClass, title, description }) => marinate`
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>${title}</title>
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />

--- a/server/template.js
+++ b/server/template.js
@@ -15,6 +15,10 @@ try {
   // console.error(err, ' mani fest error')
 }
 
+/*
+<html lang="en">
+TODO: language attribute is hard coded for now, make it dynamic when actual language support is added.
+*/
 export default ({ url, bodyClass, title, description }) => marinate`
 <!DOCTYPE html>
 <html lang="en">
@@ -155,7 +159,7 @@ export default ({ url, bodyClass, title, description }) => marinate`
     var d = new Date();
     document.getElementById("year").innerHTML = d.getFullYear();
   </script>
-  
+
 <!-- freshwork widget -->
 <script> window.fwSettings={ 'widget_id':63000000151 }; !function(){if("function"!=typeof window.FreshworksWidget){var n=function(){n.q.push(arguments)};n.q=[],window.FreshworksWidget=n}}() </script> <script type='text/javascript' src='https://widget.freshworks.com/widgets/63000000151.js' async></script>
 

--- a/src/js/components/ClearSearchButton.js
+++ b/src/js/components/ClearSearchButton.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import CrossIcon from './Icons/Times';
+
+const ClearSearchButton = ({clickHandler}) => {
+  return <button
+    type="button"
+    className="clear-search-toggle"
+    onClick={clickHandler('')}
+    aria-label="clear search"
+  >
+    <CrossIcon />
+  </button>
+}
+
+export default ClearSearchButton;

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -6,11 +6,11 @@ import { connect } from 'react-redux';
 
 import { EnhancedGurmukhiKeyboard } from './EnhancedGurmukhiKeyboard';
 import SearchForm from './SearchForm';
-import CrossIcon from './Icons/Times';
 import Menu from './HeaderMenu';
 import SearchIcon from './Icons/Search';
 import Reset from './Icons/Reset';
 import Autocomplete from '@/components/Autocomplete';
+import ClearSearchButton from '@/components/ClearSearchButton';
 import GurmukhiKeyboardToggleButton from '@/components/GurmukhiKeyboardToggleButton';
 import { toggleSettingsPanel } from '@/features/actions';
 
@@ -186,6 +186,7 @@ class Header extends React.PureComponent {
                                     className="hidden"
                                     defaultValue={type}
                                     id="search-type-value"
+                                    type="hidden"
                                     hidden
                                   />
                                 </li>
@@ -194,6 +195,7 @@ class Header extends React.PureComponent {
                                     name="source"
                                     defaultValue={source}
                                     className="hidden"
+                                    type="hidden"
                                     id="search-source-value"
                                     hidden
                                   />
@@ -219,19 +221,14 @@ class Header extends React.PureComponent {
                                       min={name === 'ang' ? 1 : undefined}
                                       max={name === 'ang' ? MAX_ANGS[source] : undefined}
                                     />
-
-                                    <button
-                                      type="button"
-                                      className="clear-search-toggle"
-                                      onClick={setQueryAs('')}
-                                    >
-                                      <CrossIcon />
-                                    </button>
-
+                                    <ClearSearchButton clickHandler={setQueryAs} />
                                     {isShowKeyboard && <GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />}
 
                                     <button
-                                      type="submit" disabled={disabled}>
+                                      type="submit"
+                                      disabled={disabled}
+                                      aria-label="search"
+                                    >
                                       <SearchIcon />
                                     </button>
 

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SOURCES, SEARCH_TYPES, TYPES, SOURCES_WITH_ANG, MAX_ANGS, SOURCE_WRITER_FILTER } from '../constants';
+import { SOURCES, SEARCH_TYPES, TYPES, SOURCES_WITH_ANG, MAX_ANGS, SOURCE_WRITER_FILTER, TEXTS } from '../constants';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
@@ -20,6 +20,9 @@ import {
   getShabadList,
   reformatSearchTypes
 } from '@/util';
+
+const { BACK_TO_HOME } = TEXTS;
+
 class Header extends React.PureComponent {
   static defaultProps = { isHome: false, location: { search: '' } };
 
@@ -90,7 +93,7 @@ class Header extends React.PureComponent {
       <div className="top-bar no-select" id="controller-bar">
         <div className="top-bar-wrapper row controller-header">
           <div className="top-bar-title">
-            <Link id="sync-logo" to="/" />
+            <Link id="sync-logo" to="/">back to home</Link>
             <span className="logo-text"><span className="bolder">Bani</span> Controller</span>
           </div>
           <div className="responsive-menu">
@@ -114,11 +117,15 @@ class Header extends React.PureComponent {
                 {showDoodle ?
                   (<>
                     <Link to="/" title={doodleData['Description']} className="doodle-link icon"
-                      style={{ backgroundImage: `url(${doodleData['ImageSquare']}) ` }} />
+                      style={{ backgroundImage: `url(${doodleData['ImageSquare']}) ` }}>
+                      {BACK_TO_HOME}
+                    </Link>
                     <Link to="/" title={doodleData['Description']} className="doodle-link bigger-image"
-                      style={{ backgroundImage: `url(${doodleData['Image']}) ` }} />
+                      style={{ backgroundImage: `url(${doodleData['Image']}) ` }}>
+                      {BACK_TO_HOME}
+                    </Link>
                   </>) :
-                  (<Link to="/" />)
+                  (<Link to="/" className="transparent-color">{BACK_TO_HOME}</Link>)
                 }
               </div>
             </>)}
@@ -251,7 +258,7 @@ class Header extends React.PureComponent {
                                   </div>
                                 </li>
                               </ul>
-                            </form>                            
+                            </form>
                           </>
                         )}
                       </div>
@@ -260,33 +267,33 @@ class Header extends React.PureComponent {
                       />
                     </div>
                     {!isHome && (
-                    <div id="search-options">
-                      <select
-                        name="type"
-                        id="search-type"
-                        value={type.toString()}
-                        onChange={handleSearchTypeChange}
-                      >
-                        {reformatSearchTypes(TYPES).map(({ type, value }) => (
-                          <option key={value} value={value}>
-                            {type}
-                          </option>
-                        ))}
-                      </select>
-                      {parseInt(type) === SEARCH_TYPES['ANG'] ? (
+                      <div id="search-options">
                         <select
-                          name="source"
-                          value={Object.keys(SOURCES_WITH_ANG).includes(source) ? source : 'G'}
-                          onChange={handleSearchSourceChange}
-                          className={[isSourceChanged ? 'selected' : null]}
+                          name="type"
+                          id="search-type"
+                          value={type.toString()}
+                          onChange={handleSearchTypeChange}
                         >
-                          {Object.entries(SOURCES_WITH_ANG).map(([value, children]) => (
+                          {reformatSearchTypes(TYPES).map(({ type, value }) => (
                             <option key={value} value={value}>
-                              {children}
+                              {type}
                             </option>
                           ))}
                         </select>
-                      ) : (
+                        {parseInt(type) === SEARCH_TYPES['ANG'] ? (
+                          <select
+                            name="source"
+                            value={Object.keys(SOURCES_WITH_ANG).includes(source) ? source : 'G'}
+                            onChange={handleSearchSourceChange}
+                            className={[isSourceChanged ? 'selected' : null]}
+                          >
+                            {Object.entries(SOURCES_WITH_ANG).map(([value, children]) => (
+                              <option key={value} value={value}>
+                                {children}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
                           <select
                             name="source"
                             value={source}
@@ -298,32 +305,32 @@ class Header extends React.PureComponent {
                                 {children}
                               </option>
                             ))}
-                          </select>)}                                                       
-                          <select
-                            name="writer"
-                            value={writer}
-                            onChange={handleSearchWriterChange}
-                            className={[isWriterChanged ? 'selected' : null]}>
-                              {
-                                writers?.filter(e => 
-                                  source === 'G' || source === 'A' ? !SOURCE_WRITER_FILTER[source].includes(e.writerID)
-                                  : source !== 'all' ? SOURCE_WRITER_FILTER[source].includes(e.writerID)
+                          </select>)}
+                        <select
+                          name="writer"
+                          value={writer}
+                          onChange={handleSearchWriterChange}
+                          className={[isWriterChanged ? 'selected' : null]}>
+                          {
+                            writers?.filter(e =>
+                              source === 'G' || source === 'A' ? !SOURCE_WRITER_FILTER[source].includes(e.writerID)
+                                : source !== 'all' ? SOURCE_WRITER_FILTER[source].includes(e.writerID)
                                   : true
-                                ).map(writer => (
-                                  <option key={writer.writerID} value={writer.writerID}>
-                                    {writer.writerEnglish}
-                                  </option>
-                                ))
-                              }
-                          </select>
-                          <button 
-                            className="reset"
-                            onClick={handleReset}
-                            title="Reset"
-                            aria-label="Reset">
-                            <Reset />
-                          </button>
-                        </div>
+                            ).map(writer => (
+                              <option key={writer.writerID} value={writer.writerID}>
+                                {writer.writerEnglish}
+                              </option>
+                            ))
+                          }
+                        </select>
+                        <button
+                          className="reset"
+                          onClick={handleReset}
+                          title="Reset"
+                          aria-label="Reset">
+                          <Reset />
+                        </button>
+                      </div>
                     )}
                   </div>
                 </React.Fragment>

--- a/src/js/constants/texts.ts
+++ b/src/js/constants/texts.ts
@@ -87,4 +87,5 @@ export const TEXTS = {
   HUKAMNAMA_NOT_FOUND_DESCRIPTION:
     "We couldn't find the hukamnama for this date in our database.",
   TOGGLE_GURMUKHI_KEYBOARD: "toggle gurmukhi keyboard",
+  BACK_TO_HOME: "back to home",
 };

--- a/src/js/pages/Help/index.js
+++ b/src/js/pages/Help/index.js
@@ -11,7 +11,7 @@ const content = {
       `How do I use a QWERTY keyboard to type Gurmukhi?`,
       <React.Fragment>
         Please reference the following keyboard map:
-        <img src="/assets/images/help/web-desktop-keyboard-map.png" />
+        <img src="/assets/images/help/web-desktop-keyboard-map.png" alt="How do I use a QWERTY keyboard to type Gurmukhi?" />
       </React.Fragment>,
     ],
     [
@@ -140,7 +140,7 @@ const content = {
         Split view separates the gurmukhi, transliteration, and translations
         into individual sections on the page. To access this option, open
         display settings, and choose “Split View”
-        <img src="/assets/images/help/web-split-view.png" />
+        <img src="/assets/images/help/web-split-view.png" alt="What is Split View?" />
       </React.Fragment>,
     ],
     [
@@ -151,7 +151,7 @@ const content = {
         shareable. You can do this by clicking any of the social media icons in
         the shabad view, or pressing the last icon to copy the link to your
         clipboard
-        <img src="/assets/images/help/web-share-link-shortener.png" />
+        <img src="/assets/images/help/web-share-link-shortener.png" alt="How do I share a shabad and use the link shortener?" />
         Additionally, for more advanced ways of using the link shortener, you
         have the following options:
         <ul>
@@ -244,7 +244,7 @@ const content = {
         </a>{' '}
         and choosing the Windows or macOS download link. After that, open the
         installer and follow the steps that are displayed.
-        <img src="/assets/images/help/desktop-download.png" />
+        <img src="/assets/images/help/desktop-download.png" alt="How do I install the desktop application?" />
       </React.Fragment>,
     ],
     [
@@ -253,10 +253,10 @@ const content = {
         After launching STTM, by default you can search for a shabad by entering
         the first letter of each word. For example, if the shabad is ਗੁਰੁ ਮੇਰੈ
         ਸੰਗਿ ਸਦਾ ਹੈ ਨਾਲੇ , you would enter <code>gmsshn</code>.
-        <img src="/assets/images/help/desktop-search-ex.png" />
+        <img src="/assets/images/help/desktop-search-ex.png" alt="desktop search example" />
         Alternatively, you can click on the gurmukhi keyboard icon and type in
         the letters manually.
-        <img src="/assets/images/help/desktop-keyboard.png" />
+        <img src="/assets/images/help/desktop-keyboard.png" alt="desktop search keyboard" />
       </React.Fragment>,
     ],
     [
@@ -329,8 +329,8 @@ const content = {
         your computer's display settings and change it to "Extended Desktop"
         (NOT mirroring). After that, launch STTM and turn on "Presenter View" in
         the settings!
-        <img src="/assets/images/help/desktop-extend-pc.png" />
-        <img src="/assets/images/help/desktop-extend-mac.png" />
+        <img src="/assets/images/help/desktop-extend-pc.png" alt="connect STTM to a projector on PC" />
+        <img src="/assets/images/help/desktop-extend-mac.png" alt="connect STTM to a projector on Mac" />
       </React.Fragment>,
     ],
     [
@@ -338,7 +338,7 @@ const content = {
       <React.Fragment>
         After launching STTM, click the icon for settings, and choose your
         theme.
-        <img src="/assets/images/help/desktop-theme.png" />
+        <img src="/assets/images/help/desktop-theme.png" alt="Theme options" />
       </React.Fragment>,
     ],
     [
@@ -346,7 +346,7 @@ const content = {
       <React.Fragment>
         Yes! After launching STTM, click the icon for settings, and choose the
         Larivaar option.
-        <img src="/assets/images/help/desktop-larivaar.png" />
+        <img src="/assets/images/help/desktop-larivaar.png" alt="Gurbani in Larivaar" />
       </React.Fragment>,
     ],
     [
@@ -354,7 +354,7 @@ const content = {
       <React.Fragment>
         After launching STTM, click the icon for settings, and scroll down for
         options to adjust the font size.
-        <img src="/assets/images/help/desktop-font-size.png" />
+        <img src="/assets/images/help/desktop-font-size.png" alt="How can I make the fonts on the screen smaller?" />
       </React.Fragment>,
     ],
     [
@@ -363,7 +363,7 @@ const content = {
         When using STTM in “Presenter View”, your history will appear in the
         bottom right quadrant. You can click any of the shabads in the list to
         bring them back up as your primary one.
-        <img src="/assets/images/help/desktop-history.png" />
+        <img src="/assets/images/help/desktop-history.png" alt="Where can I see my previous shabads?" />
       </React.Fragment>,
     ],
     [
@@ -375,8 +375,8 @@ const content = {
         Shabad you started with. Additionally, you can press the arrows in the
         menu bar to quickly go to the next/previous Shabad without having to
         scroll at all.
-        <img src="/assets/images/help/desktop-akhand-paatth-view-toggle.png" />
-        <img src="/assets/images/help/desktop-akhand-paatth-view.png" />
+        <img src="/assets/images/help/desktop-akhand-paatth-view-toggle.png" alt="Akhand Paatth view toggle button" />
+        <img src="/assets/images/help/desktop-akhand-paatth-view.png" alt="Akhand Paatth view" />
       </React.Fragment>,
     ],
     [
@@ -400,8 +400,8 @@ const content = {
             for Gurmukhi if you'd like to use that instead.
           </li>
         </ul>
-        <img src="/assets/images/help/desktop-custom-slide-button.png" />
-        <img src="/assets/images/help/desktop-custom-slide-controller.png" />
+        <img src="/assets/images/help/desktop-custom-slide-button.png" alt="Custom slide button" />
+        <img src="/assets/images/help/desktop-custom-slide-controller.png" alt="Custom slide controller" />
         To get to the "Custom Slides" feature, click on slides icon on the top
         right when viewing a Shabad.
       </React.Fragment>,

--- a/src/js/pages/Home/index.js
+++ b/src/js/pages/Home/index.js
@@ -12,9 +12,9 @@ import SehajPaathLink from '@/components/SehajPaathLink';
 import { BaaniLinks } from '@/components/BaaniLinks/';
 import SearchForm from '@/components/SearchForm';
 import Logo from '@/components/Icons/Logo';
-import CrossIcon from '@/components/Icons/Times';
 import SearchIcon from '@/components/Icons/Search';
 import Autocomplete from '@/components/Autocomplete';
+import ClearSearchButton from '@/components/ClearSearchButton';
 import Reset from '@/components/Icons/Reset';
 import GurmukhiKeyboardToggleButton from '@/components/GurmukhiKeyboardToggleButton';
 /**
@@ -136,13 +136,7 @@ export default class Home extends React.PureComponent {
                         min={name === 'ang' ? 1 : undefined}
                         max={name === 'ang' ? MAX_ANGS[source] : undefined}
                       />
-                      <button
-                        type="button"
-                        className="clear-search-toggle"
-                        onClick={setQueryAs('')}
-                      >
-                        <CrossIcon />
-                      </button>
+                      <ClearSearchButton clickHandler={setQueryAs} />
                       {isShowKeyboard && <GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />}
                       <button type="submit" disabled={disabled}>
                         <SearchIcon />

--- a/src/js/pages/WebController/search-input.js
+++ b/src/js/pages/WebController/search-input.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CrossIcon from '../../components/Icons/Times';
 import SearchIcon from '../../components/Icons/Search';
 import { EnhancedGurmukhiKeyboard } from '../../components/EnhancedGurmukhiKeyboard';
 import GurmukhiKeyboardToggleButton from '../../components/GurmukhiKeyboardToggleButton';
 import SearchForm from '../../components/SearchForm';
+import ClearSearchButton from '../../components/ClearSearchButton';
 
 import {
   SOURCES,
@@ -100,14 +100,7 @@ export default class SearchInput extends React.PureComponent {
                         title={title}
                         pattern={pattern}
                       />
-                      <button
-                        type="button"
-                        className="clear-search-toggle"
-                        onClick={setQueryAs('')}
-                      >
-                        <CrossIcon />
-                      </button>
-                      
+                      <ClearSearchButton clickHandler={setQueryAs} />
                       {type > 2 ? '' : (<GurmukhiKeyboardToggleButton clickHandler={setGurmukhiKeyboardVisibilityAs} isVisible={displayGurmukhiKeyboard} />)}
                       
                       <button type="submit">

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -68,7 +68,7 @@ footer {
     }
 
     .footer-seperator {
-      color: $sttm-lighter-grey;
+      color: $sttm-darkest-grey;
       display: block;
       font-size: 0.9em;
       line-height: 1;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -344,3 +344,7 @@ select {
     font-size: 1rem;
   }
 }
+
+body:not(.dark-mode) a {
+  color: #1374b4;
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -348,3 +348,7 @@ select {
 body:not(.dark-mode) a {
   color: #1374b4;
 }
+
+.transparent-color {
+  color: transparent !important;
+}


### PR DESCRIPTION
- add missing lang attribute on `<html>` tag
- add accessible color for links on non-dark mode
- add aria-label for empty text CTAs
- add text to blank link

## No more Errors and contrast issues on help page
![help_page](https://user-images.githubusercontent.com/3865313/115957352-24273900-a502-11eb-998d-52fe8787e6cb.png)

### Pending (can be part of new PR)
- We should add language attribute wherever we are using non-English language, see example below:
`<span lang="pa" xml:lang="pa">Punjabi text</span>`

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).