### PR TITLE
Change name of menu to avoid being blocked by content blockers

### DIFF
--- a/src/js/components/ShareButtons.js
+++ b/src/js/components/ShareButtons.js
@@ -196,7 +196,7 @@ class ShareButtons extends React.PureComponent {
 
     if (window !== undefined && 'share' in window.navigator) {
       return (
-        <div id="share-menu">
+        <div id="controls-menu">
           <ul className="share-buttons">
             <li>
               <a title="Open Share Dialog" onClick={ShareButtons.handleShare}>
@@ -211,7 +211,7 @@ class ShareButtons extends React.PureComponent {
     }
 
     return (
-      <div id="share-menu">
+      <div id="controls-menu">
         <ul className="share-buttons">{media.map(item => mediaMap[item])}</ul>
       </div>
     );

--- a/src/scss/_printer.scss
+++ b/src/scss/_printer.scss
@@ -23,7 +23,7 @@
   #responsive-menu,
   #search-options,
   #controls-wrapper,
-  #share-menu,
+  #controls-menu,
   footer,
   .breadcrumb,
   .shabad-nav,

--- a/src/scss/_shabad-page.scss
+++ b/src/scss/_shabad-page.scss
@@ -526,7 +526,7 @@ blockquote {
     padding: 4px 2rem 0 3rem;
   }
 
-  .dark-mode #share-menu {
+  .dark-mode #controls-menu {
     background-color: $sttm-light-black;
   }
 }

--- a/src/scss/_sharing.scss
+++ b/src/scss/_sharing.scss
@@ -36,7 +36,7 @@
   }
 }
 
-#share-menu {
+#controls-menu {
   border-radius: 2px;
   margin: 0 2rem 0 auto;
 
@@ -155,7 +155,7 @@
 
 @media screen and (max-width: 45.999999em) {
   .share-buttons,
-  #share-menu {
+  #controls-menu {
     .dark-mode & {
       background-color: $sttm-light-black;
     }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -112,7 +112,7 @@ select {
     display: none;
   }
 
-  + #share-menu {
+  + #controls-menu {
     margin-top: -27px;
 
     @media screen and (max-width: 950px) {


### PR DESCRIPTION
This changes the name of the div from `share-menu` to `controls-menu` to avoid being removed by common adblock cosmetic filters (ublock/etc). 

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).