### PR TITLE
Remove http protocol from the hukam audio url

### DIFF
--- a/src/js/constants/misc.ts
+++ b/src/js/constants/misc.ts
@@ -18,5 +18,5 @@ export const TYPES = _TYPES.filter((value, index) =>
 
 export const SHORT_DOMAIN = 'sttm.co';
 export const MAHANKOSH_TOOLTIP_SOURCE = 'Source: Mahaan Kosh (Encyclopedia)';
-export const HUKAMNAMA_AUDIO_URL='http://old.sgpc.net/hukumnama/jpeg%20hukamnama/hukamnama.mp3';
+export const HUKAMNAMA_AUDIO_URL='//old.sgpc.net/hukumnama/jpeg%20hukamnama/hukamnama.mp3';
 export const API_URL = "https://audio.sikhitothemax.org/v1/";


### PR DESCRIPTION
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.


Currently we see a non secure label on the hukamnama page, because we are getting the hukam audio with http. 
![image](https://github.com/KhalisFoundation/sttm-web/assets/1990932/51b8f2ba-ff13-4ea4-ab84-e19fa44de63f)

I removed the protocol from hukam audio link to fix this. Tested it via ngrok
![image](https://github.com/KhalisFoundation/sttm-web/assets/1990932/a53cb748-8cc2-47ff-b8e2-ed852e46f252)

