### PR TITLE
Moving semantic search API to Google cloud run

### DIFF
--- a/common/api-urls-constants.js
+++ b/common/api-urls-constants.js
@@ -14,5 +14,5 @@ module.exports = {
   CEREMONIES: '//api.sikhitothemax.org/ceremonies/',
   DOODLE: '//api.sikhitothemax.org/doodle/',
   WRITERS: '//api.banidb.com/v2/writers/',
-  GURBANIBOT: '//fastersemanticsearchapi.sevaa.win/'
+  GURBANIBOT: '//gurbanichatbot.sikhitothemax.org/'
 };


### PR DESCRIPTION
With google cloud run, the API is hosted at gurbanichatbot.sikhitothemax.org