### PR TITLE
Revert "Change the API url to banidb.khalis.dev"

### DIFF
--- a/common/api-urls-constants.js
+++ b/common/api-urls-constants.js
@@ -1,13 +1,11 @@
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
-  BANIS: isProduction
-    ? '//banidb.khalis.dev/v2/banis'
-    : '//api.khajana.org/v2/banis',
-  PRODUCTION: '//banidb.khalis.dev/v2/',
+  BANIS: isProduction ? '//api.banidb.com/v2/banis' : "//api.khajana.org/v2/banis",
+  PRODUCTION: '//api.banidb.com/v2/',
   DEVELOPMENT: '//api.khajana.org/v2/',
-  AMRIT_KEERTAN: '//banidb.khalis.dev/v2/amritkeertan',
-  AMRIT_KEERTAN_SHABADS: '//banidb.khalis.dev/v2/shabads',
+  AMRIT_KEERTAN: '//api.banidb.com/v2/amritkeertan',
+  AMRIT_KEERTAN_SHABADS: '//api.banidb.com/v2/shabads',
   BANNERS: '//api.sikhitothemax.org/messages/web',
   SYNC: {
     PRODUCTION: '//api.sikhitothemax.org/',
@@ -15,6 +13,6 @@ module.exports = {
   },
   CEREMONIES: '//api.sikhitothemax.org/ceremonies/',
   DOODLE: '//api.sikhitothemax.org/doodle/',
-  WRITERS: '//banidb.khalis.dev/v2/writers/',
-  GURBANIBOT: '//gurbanichatbot.sikhitothemax.org/',
+  WRITERS: '//api.banidb.com/v2/writers/',
+  GURBANIBOT: '//gurbanichatbot.sikhitothemax.org/'
 };


### PR DESCRIPTION
Reverts KhalisFoundation/sttm-web#1784

Switches back to use the production API instead of temporary API URL.