### PR TITLE
Remove node_env from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY . .
 RUN npm install --legacy-peer-deps
 
 # Set the environment to production and expose your app port
-ENV NODE_ENV=production
 EXPOSE 8080
 
 RUN npm run build


### PR DESCRIPTION
Removing env variable `NODE_ENV` from `Dockerfile` as the same dockerfile would be used for dev deployments.