### PR TITLE
Fix the autoplay not working

### DIFF
--- a/src/js/components/AutoScrollControl/AutoScrollControl.tsx
+++ b/src/js/components/AutoScrollControl/AutoScrollControl.tsx
@@ -172,9 +172,11 @@ class AutoScrollControl extends React.PureComponent<
         2
       );
 
-      // Update next position and scroll
-      this._nextScrollPosition = scrollY + movement;
-      window.scrollTo(0, Math.round(this._nextScrollPosition));
+      if (scrollY >= Math.round(this._nextScrollPosition)) {
+        // Update next position and scroll
+        this._nextScrollPosition = scrollY + movement;
+        window.scrollTo(0, Math.round(this._nextScrollPosition));
+      }
 
       this._interval = requestAnimationFrame(this.handleAutoScroll);
     }

--- a/src/js/components/AutoScrollControl/AutoScrollControl.tsx
+++ b/src/js/components/AutoScrollControl/AutoScrollControl.tsx
@@ -3,14 +3,14 @@ import { connect } from 'react-redux';
 import { Range } from 'react-range';
 
 import { toFixedFloat } from '../../util/numbers';
-import { Pause, Play,Loop } from "../../components/Icons/controls";
+import { Pause, Play, Loop } from '../../components/Icons/controls';
 import { setAutoScrolling } from '@/features/actions';
 
 interface IReduxStateAsProps {
   isAutoScrolling?: boolean;
 }
 interface IReduxDispatchProps {
-  setAutoScrolling?: (action: boolean) => {}
+  setAutoScrolling?: (action: boolean) => {};
 }
 
 interface IAutoScrollControlState {
@@ -22,40 +22,44 @@ interface IAutoScrollControlState {
 // Hidden controls controlsState will have all the controls hidden by default and shown only when playing
 // Visible controls isControlsVisible will have all the controls visible all the time.
 type HideSliderScreenSize = 'never' | 'mobile' | 'tablet' | 'desktop';
-interface IAutoScrollControlProps extends IReduxDispatchProps, IReduxStateAsProps {
+interface IAutoScrollControlProps
+  extends IReduxDispatchProps,
+    IReduxStateAsProps {
   hideSliderScreenSize: HideSliderScreenSize;
   isControlsAlwaysVisible: boolean;
   isBackgroundTransparent: boolean;
   isLoadingAng: boolean;
 }
 
-class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAutoScrollControlState> {
-
+class AutoScrollControl extends React.PureComponent<
+  IAutoScrollControlProps,
+  IAutoScrollControlState
+> {
   static maxScrollingSpeed = 100;
   static minScrollingSpeed = 1;
   // static lowerSpeedThreshHold = 0.4;
   // static higherSpeedThreshHold = 1.2;
   static thresHold = 3.33;
-  _maxScrollPossible!: number;
-  _nextScrollPosition!: number;
-  _sliding!: boolean;
-  _interval!: number;
+  _maxScrollPossible: number = 0;
+  _nextScrollPosition: number = 0;
+  _sliding: boolean = false;
+  _interval: number = 0;
   _isFirefoxAgent: boolean = false;
 
   static defaultProps = {
     isBackgroundTransparent: false,
     isControlsAlwaysVisible: true,
     hideSliderScreenSize: 'never',
-  }
+  };
 
   constructor(props: Readonly<IAutoScrollControlProps>) {
-    super(props)
+    super(props);
 
     this.state = {
       isScrolling: this.props.isAutoScrolling || false,
       scrollingSpeed: [30],
-      autoScrollLoopMode: false
-    }
+      autoScrollLoopMode: false,
+    };
   }
 
   getHideSliderClass = () => {
@@ -63,30 +67,39 @@ class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAu
     if (hideSliderScreenSize === 'never') return '';
 
     return `hide-${hideSliderScreenSize}`;
-  }
+  };
 
   handleScrollSpeedChange = (newSpeed: number[]) => {
     if (!this._sliding) {
       requestAnimationFrame(() => {
         this.setState(
           (state) => ({ ...state, scrollingSpeed: newSpeed }),
-          () => { this._sliding = false })
+          () => {
+            this._sliding = false;
+          }
+        );
       });
       this._sliding = true;
     }
-  }
+  };
 
   setSpeed = (operation: string) => () => {
     const [scrollingSpeed] = this.state.scrollingSpeed;
     let newScrollingSpeed: number = 0;
 
     if (operation === 'increment')
-      newScrollingSpeed = Math.min(scrollingSpeed + 10, AutoScrollControl.maxScrollingSpeed)
+      newScrollingSpeed = Math.min(
+        scrollingSpeed + 10,
+        AutoScrollControl.maxScrollingSpeed
+      );
     else
-      newScrollingSpeed = Math.max(scrollingSpeed - 10, AutoScrollControl.minScrollingSpeed);
+      newScrollingSpeed = Math.max(
+        scrollingSpeed - 10,
+        AutoScrollControl.minScrollingSpeed
+      );
 
     this.handleScrollSpeedChange([newScrollingSpeed]);
-  }
+  };
 
   toggleAutoScrollState = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -97,74 +110,75 @@ class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAu
     } else {
       this.startScroll();
     }
-  }
+  };
 
   handleIconClick = (e: React.MouseEvent) => {
     e.preventDefault();
-  }
+  };
 
   clearScrollInterval = () => {
-    cancelAnimationFrame(this._interval)
-  }
+    cancelAnimationFrame(this._interval);
+  };
 
   startScroll = () => {
     this.props.setAutoScrolling && this.props.setAutoScrolling(true);
-    this._nextScrollPosition = document.documentElement.scrollTop;
+    this._nextScrollPosition =
+      window.pageYOffset || document.documentElement.scrollTop;
     this._setMaxScrollPossible();
     this._interval = requestAnimationFrame(this.handleAutoScroll);
-  }
+  };
 
   handleScrollbarClick = (e: MouseEvent) => {
-    const isScrollbarClicked = window.innerWidth >= e.pageX && e.pageX >= document.body.scrollWidth;
+    const isScrollbarClicked =
+      window.innerWidth >= e.pageX && e.pageX >= document.body.scrollWidth;
     if (isScrollbarClicked) {
+      e.preventDefault();
+      e.stopPropagation();
       this.removeScroll();
     }
-  }
+  };
 
   removeScroll = () => {
     this.props.setAutoScrolling && this.props.setAutoScrolling(false);
-    this.clearScrollInterval()
-  }
+    this.clearScrollInterval();
+  };
 
   _setMaxScrollPossible = () => {
-    this._maxScrollPossible = document.documentElement.scrollHeight - window.innerHeight;
-  }
+    this._maxScrollPossible =
+      document.documentElement.scrollHeight - window.innerHeight;
+  };
 
   handleAutoScroll = () => {
     if (this.props.isAutoScrolling) {
-      const scrollY = document.documentElement.scrollTop;
-      if (scrollY >= this._maxScrollPossible && !this.props.isLoadingAng) {
-        // we are resetting the maxscroll value since it can hold old value by now.
-        this._setMaxScrollPossible();
+      const scrollY = window.pageYOffset || document.documentElement.scrollTop;
 
+      if (scrollY >= this._maxScrollPossible && !this.props.isLoadingAng) {
+        this._setMaxScrollPossible();
         const isMaxScrollCrossed = this._maxScrollPossible >= scrollY;
         if (isMaxScrollCrossed) {
           this.removeScroll();
-          if(this.state.autoScrollLoopMode){
-            const timeoutInterval = setTimeout(() => {
-              window.scrollTo(0, 0);
-              setTimeout(() => {
-                this.startScroll();
-                clearTimeout(timeoutInterval);
-              }, 1000);
-            },1000)
+          if (this.state.autoScrollLoopMode) {
+            window.scrollTo(0, 0);
+            setTimeout(() => {
+              this.startScroll();
+            }, 1000);
           }
         }
       }
 
       const [scrollingSpeed] = this.state.scrollingSpeed;
+      const movement = toFixedFloat(
+        0.1 + (scrollingSpeed / 100) * AutoScrollControl.thresHold,
+        2
+      );
 
-      // We are having minimum scroll per pixel + adding the extra dynamic pixel movement based on slider value.
-      const movement = toFixedFloat((0.1 + ((scrollingSpeed / 100) * AutoScrollControl.thresHold)), 2);
-      // Only allow the scrolling if we have surpassed previous scrolls or if it's firefox browser.
-      if (this._isFirefoxAgent || scrollY >= Math.round(this._nextScrollPosition)) {
-        this._nextScrollPosition += movement;
-        window.scrollTo({ left: 0, top: Math.round(this._nextScrollPosition)});
-      }
+      // Update next position and scroll
+      this._nextScrollPosition = scrollY + movement;
+      window.scrollTo(0, Math.round(this._nextScrollPosition));
 
       this._interval = requestAnimationFrame(this.handleAutoScroll);
     }
-  }
+  };
 
   setAutoScrollModeDOMChanges = (isShown: boolean) => {
     const body = document.body;
@@ -173,28 +187,28 @@ class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAu
     } else {
       body.classList.remove('autoscroll-mode');
     }
-  }
+  };
 
   addListeners = () => {
-    window.addEventListener("mousedown", this.handleScrollbarClick);
-    window.addEventListener("touchmove", this.removeScroll);
-    window.addEventListener("wheel", this.removeScroll);
-  }
+    window.addEventListener('mousedown', this.handleScrollbarClick);
+    window.addEventListener('touchmove', this.removeScroll);
+    window.addEventListener('wheel', this.removeScroll);
+  };
 
   removeListeners = () => {
-    window.removeEventListener("mousedown", this.handleScrollbarClick);
-    window.removeEventListener("wheel", this.removeScroll);
-    window.removeEventListener("touchmove", this.removeScroll);
-  }
+    window.removeEventListener('mousedown', this.handleScrollbarClick);
+    window.removeEventListener('wheel', this.removeScroll);
+    window.removeEventListener('touchmove', this.removeScroll);
+  };
 
   componentDidMount = () => {
     this.addListeners();
 
-    this._isFirefoxAgent = navigator.userAgent.indexOf("Firefox") > -1;
+    this._isFirefoxAgent = navigator.userAgent.indexOf('Firefox') > -1;
 
     // For now, once this component mounts we are in autoscroll-mode.
     this.setAutoScrollModeDOMChanges(true);
-  }
+  };
 
   componentWillUnmount = () => {
     this.clearScrollInterval();
@@ -203,35 +217,49 @@ class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAu
     //Force this to remove the autoscroll-mode class from the body.
     this.setAutoScrollModeDOMChanges(false);
   };
-  toggleAutoScrollLoopMode=()=>{
-    this.setState({autoScrollLoopMode:!this.state.autoScrollLoopMode})
-  }
+  toggleAutoScrollLoopMode = () => {
+    this.setState({ autoScrollLoopMode: !this.state.autoScrollLoopMode });
+  };
   render() {
-
-    const { scrollingSpeed,autoScrollLoopMode } = this.state;
+    const { scrollingSpeed, autoScrollLoopMode } = this.state;
     const hideSliderClass = this.getHideSliderClass();
     const {
       isBackgroundTransparent,
       isAutoScrolling,
-      isControlsAlwaysVisible
+      isControlsAlwaysVisible,
     } = this.props;
-    const autoScrollControlBgClass = isBackgroundTransparent ? 'backgroundTransparent' : '';
+    const autoScrollControlBgClass = isBackgroundTransparent
+      ? 'backgroundTransparent'
+      : '';
     const isShowControls = isControlsAlwaysVisible || isAutoScrolling;
 
     return (
       <div className={`autoScrollControl ${autoScrollControlBgClass}`}>
         <div className="autoScrollControlSpeed">
-          <div className={`autoScrollControlGroup ${isShowControls ? 'visible' : 'hidden'}`}>
+          <div
+            className={`autoScrollControlGroup ${
+              isShowControls ? 'visible' : 'hidden'
+            }`}
+          >
             <label className="autoScrollControlSliderLabel">
               Speed {`(${scrollingSpeed})`}
             </label>
             <div className="autoScrollControlSlider">
-              <button onClick={this.toggleAutoScrollLoopMode} className={`autoScrollLoopModeBtn ${autoScrollLoopMode ? 'on':''}`}>
+              <button
+                onClick={this.toggleAutoScrollLoopMode}
+                className={`autoScrollLoopModeBtn ${
+                  autoScrollLoopMode ? 'on' : ''
+                }`}
+              >
                 <Loop />
               </button>
               <button
                 className="autoScrollControlDecreaseSpeed"
-                onClick={this.setSpeed('decrement')}> - </button>
+                onClick={this.setSpeed('decrement')}
+              >
+                {' '}
+                -{' '}
+              </button>
               <Range
                 step={1}
                 min={AutoScrollControl.minScrollingSpeed}
@@ -247,34 +275,53 @@ class AutoScrollControl extends React.PureComponent<IAutoScrollControlProps, IAu
                   </div>
                 )}
                 renderThumb={({ props }) => (
-                  <div className={`autoScrollControlSliderThumb ${hideSliderClass}`}
+                  <div
+                    className={`autoScrollControlSliderThumb ${hideSliderClass}`}
                     {...props}
                   />
                 )}
               />
               <button
                 className="autoScrollControlIncreaseSpeed"
-                onClick={this.setSpeed('increment')}> + </button>
+                onClick={this.setSpeed('increment')}
+              >
+                {' '}
+                +{' '}
+              </button>
             </div>
           </div>
         </div>
         <button
           onClick={this.toggleAutoScrollState}
-          className="autoScrollControlPlayBtn">
-          {isAutoScrolling ?
-            <Pause onClick={this.handleIconClick} /> :
-            <Play onClick={this.handleIconClick} />}
+          className="autoScrollControlPlayBtn"
+        >
+          {isAutoScrolling ? (
+            <Pause onClick={this.handleIconClick} />
+          ) : (
+            <Play onClick={this.handleIconClick} />
+          )}
         </button>
       </div>
-    )
+    );
   }
 }
 
-const mapStateToProps = ({ isAutoScrolling, isLoadingAng }: any) => ({ isAutoScrolling, isLoadingAng })
+const mapStateToProps = ({ isAutoScrolling, isLoadingAng }: any) => ({
+  isAutoScrolling,
+  isLoadingAng,
+});
 
 const mapDispatchToProps: IReduxDispatchProps = {
-  setAutoScrolling
-}
+  setAutoScrolling,
+};
 
 // TODO: finding fix for proper typing this
-export default connect<{}, {}, IAutoScrollControlProps, IAutoScrollControlState>(mapStateToProps as any, mapDispatchToProps)(AutoScrollControl as any);
+export default connect<
+  {},
+  {},
+  IAutoScrollControlProps,
+  IAutoScrollControlState
+>(
+  mapStateToProps as any,
+  mapDispatchToProps
+)(AutoScrollControl as any);


### PR DESCRIPTION
**The Issue:**
The auto-scroll wasn't working properly on Windows Chrome because of how we were tracking scroll positions
The original code was incrementing _nextScrollPosition without considering the actual current scroll position:
```javascript
this._nextScrollPosition += movement;  // Problematic: Lost track of actual position
```

**The Fix:**
Changed how we calculate the next scroll position to always use the actual current position:
```javascript
this._nextScrollPosition = scrollY + movement;  // Fixed: Always based on current position
```

Also, removed the firefox specific code, as that was causing autoplay to break.

Sidenote:
Restructured the code a bit for code readablity and fixed linter errors as well.