### PR TITLE
Fix 1770 Gurmukhi encoded letters which break Mahankosh

### DIFF
--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -1069,7 +1069,7 @@ class Baani extends React.PureComponent {
   };
   render() {
     const { centerAlignGurbani, showFullScreen, isMahankoshTooltipActive } = this.props;
-    const { selectedWord } = this.state;
+    const { selectedWord, selectedWordIndex, selectedLine } = this.state;
     
     return (
       <div
@@ -1082,6 +1082,8 @@ class Baani extends React.PureComponent {
           clearMahankoshInformation={this.clearMahankoshInformation}
           tooltipId="mahankoshTooltipHighlightSearchResult"
           gurbaniWord={selectedWord}
+          gurbaniLineInfo={this.normalizeGurbani()[selectedLine - 1]}
+          wordIndex={selectedWordIndex}
         />
       </div>
     );

--- a/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
+++ b/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
@@ -14,6 +14,8 @@ interface Props {
   gurbaniWord: string;
   clearMahankoshInformation: () => {};
   isMahankoshTooltipActive: boolean;
+  gurbaniLineInfo: any;
+  wordIndex: number;
 }
 
 const MAHANKOSH_CONFIG = {
@@ -37,7 +39,9 @@ const MAHANKOSH_CONFIG = {
 export const MahankoshTooltip = (props: Props) => {
   const dispatch = useDispatch();
   
-  const url = props.gurbaniWord ? `${API_URL}kosh/word/${props.gurbaniWord}` : '';
+  const gurbaniLine: string = props.gurbaniWord ? props.gurbaniLineInfo[0].verse.unicode : '';
+  const gurbaniQuery: string = props.gurbaniWord ? gurbaniLine.split(' ')[props.wordIndex] : '';
+  const url = props.gurbaniWord ? `${API_URL}kosh/word/${gurbaniQuery}` : '';
 
   const { data: mahankoshExplaination, isLoading: isFetchingMahankoshExplaination, isSuccess } = useQuery({
     queryKey: ['mahakosh-shabad', props.gurbaniWord ],


### PR DESCRIPTION
Fix Issue 1770 to prevent special escape characters from breaking Mahankosh Tooltip (specifically ਞ Nyanya which is backslash). Force MahankoshTooltip to use unicode when querying the API for a definition.

<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.

<!-- New to markdown? Simply put an 'x' between [ ] to check it. Like [x] this. (No spaces).