### PR TITLE
Add source filter support in bot search feature

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -93,23 +93,23 @@ class Header extends React.PureComponent {
 
   onFormSubmit =
     ({ handleSubmit, autoDetectGurmukhi, ...data }) =>
-    (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      handleSubmit();
-      // Remove the last space in from the searched query.
-      const isNotAngSearch = SEARCH_TYPES[data.type] !== SEARCH_TYPES.ANG;
-      if (isNotAngSearch) {
-        data.query = data.query.trim();
-      }
+      (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        handleSubmit();
+        // Remove the last space in from the searched query.
+        const isNotAngSearch = SEARCH_TYPES[data.type] !== SEARCH_TYPES.ANG;
+        if (isNotAngSearch) {
+          data.query = data.query.trim();
+        }
 
-      const searchParams = { ...data, autoDetectGurmukhi };
-      if (data.type === SEARCH_TYPES.AUTO_DETECT && autoDetectGurmukhi) {
-        searchParams.isGurmukhi = true;
-      }
+        const searchParams = { ...data, autoDetectGurmukhi };
+        if (data.type === SEARCH_TYPES.AUTO_DETECT && autoDetectGurmukhi) {
+          searchParams.isGurmukhi = true;
+        }
 
-      this.handleFormSubmit(searchParams);
-    };
+        this.handleFormSubmit(searchParams);
+      };
 
   handleFormSubmit = (data) => {
     this.props.history.push(toSearchURL(data));
@@ -146,10 +146,10 @@ class Header extends React.PureComponent {
       type: defaultType = isAng ? SEARCH_TYPES.ANG.toString() : null,
       writer: defaultWriter = DEFAULT_SEARCH_WRITER,
       autoDetectGurmukhi:
-        defaultAutoDetectGurmukhi = getBooleanFromLocalStorage(
-          LOCAL_STORAGE_KEY_FOR_AUTO_DETECT_GURMUKHI,
-          false
-        ),
+      defaultAutoDetectGurmukhi = getBooleanFromLocalStorage(
+        LOCAL_STORAGE_KEY_FOR_AUTO_DETECT_GURMUKHI,
+        false
+      ),
     } = getQueryParams(location.search);
 
     const isAskGurbaniBotSearchType =
@@ -195,22 +195,21 @@ class Header extends React.PureComponent {
             }
             defaultSource={
               isAskGurbaniBotSearchType
-                ? localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE) ||
-                  DEFAULT_SEARCH_SOURCE
+                ? DEFAULT_SEARCH_SOURCE
                 : defaultSource
             }
             defaultType={
               isAskGurbaniBotSearchType
                 ? getNumberFromLocalStorage(
-                    LOCAL_STORAGE_KEY_FOR_SEARCH_TYPE,
-                    DEFAULT_SEARCH_TYPE
-                  )
+                  LOCAL_STORAGE_KEY_FOR_SEARCH_TYPE,
+                  DEFAULT_SEARCH_TYPE
+                )
                 : Number(defaultType)
             }
             defaultWriter={
               isAskGurbaniBotSearchType
                 ? localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER) ||
-                  DEFAULT_SEARCH_WRITER
+                DEFAULT_SEARCH_WRITER
                 : Number(defaultWriter)
             }
             defaultAutoDetectGurmukhi={defaultAutoDetectGurmukhi}
@@ -457,7 +456,7 @@ class Header extends React.PureComponent {
                                         writer,
                                         isGurmukhi:
                                           parseInt(type) ===
-                                            SEARCH_TYPES.AUTO_DETECT &&
+                                          SEARCH_TYPES.AUTO_DETECT &&
                                           autoDetectGurmukhi,
                                       }}
                                       value={query}
@@ -536,13 +535,13 @@ class Header extends React.PureComponent {
                             ?.filter((e) =>
                               source === 'G' || source === 'A'
                                 ? !SOURCE_WRITER_FILTER[source].includes(
-                                    e.writerID
-                                  )
+                                  e.writerID
+                                )
                                 : source !== 'all'
-                                ? SOURCE_WRITER_FILTER[source].includes(
+                                  ? SOURCE_WRITER_FILTER[source].includes(
                                     e.writerID
                                   )
-                                : true
+                                  : true
                             )
                             .map((writer) => (
                               <option

--- a/src/js/components/Modals/AskGurbaniBotQuestionModal.tsx
+++ b/src/js/components/Modals/AskGurbaniBotQuestionModal.tsx
@@ -8,7 +8,7 @@ import SearchIcon from '@/components/Icons/Search';
 import { toSearchURL } from '@/util';
 
 import Dialog from './Dialog';
-import { SEARCH_TYPES } from '@/constants';
+import { SEARCH_TYPES, SOURCES } from '@/constants';
 
 interface Props {
   isModalOpen: boolean;
@@ -22,24 +22,26 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
     ({
       handleFormSubmit,
       query,
+      source,
     }: {
       handleFormSubmit: FormEventHandler;
       query: string;
+      source: string;
     }) =>
-    (e: FormEvent) => {
-      e.preventDefault();
-      typeof handleFormSubmit === 'function' && handleFormSubmit();
-      history.push(
-        toSearchURL({
-          query,
-          type: SEARCH_TYPES.ASK_A_QUESTION,
-          writer: 'all',
-          source: 'all',
-          offset: '',
-        })
-      );
-      dispatch(setModalOpen(''));
-    };
+      (e: FormEvent) => {
+        e.preventDefault();
+        typeof handleFormSubmit === 'function' && handleFormSubmit();
+        history.push(
+          toSearchURL({
+            query,
+            type: SEARCH_TYPES.ASK_A_QUESTION,
+            writer: 'all',
+            source,
+            offset: '',
+          })
+        );
+        dispatch(setModalOpen(''));
+      };
 
   return (
     <Dialog
@@ -65,6 +67,9 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
             handleKeyDown,
             handleSearchChange,
             handleSubmit: handleFormSubmit,
+            source,
+            handleSearchSourceChange,
+            isSourceChanged,
           }) => (
             <form
               className="search-form"
@@ -72,6 +77,7 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
               onSubmit={handleSubmit({
                 handleFormSubmit: handleFormSubmit,
                 query,
+                source,
               })}
             >
               <div className="search-container-wrapper">
@@ -102,8 +108,25 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
                   </button>
                 </div>
               </div>
+              <div className="search-options">
+                <div className="search-option">
+                  <select
+                    name="source"
+                    value={source}
+                    className={[isSourceChanged ? 'selected' : null]}
+                    onChange={handleSearchSourceChange}
+                  >
+                    {Object.entries(SOURCES).map(([value, children]) => (
+                      <option key={value} value={value}>
+                        {children}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
             </form>
-          )}
+          )
+          }
         </SearchForm>
       </div>
     </Dialog>

--- a/src/js/components/Modals/AskGurbaniBotQuestionModal.tsx
+++ b/src/js/components/Modals/AskGurbaniBotQuestionModal.tsx
@@ -53,8 +53,9 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
           defaultType={SEARCH_TYPES.ASK_A_QUESTION}
           defaultSource="all"
           defaultWriter={0}
+          isolateFromLocalStorage // helps to keep the bot search form state isolated from the main/normal search form
         >
-          {({
+          {(({
             pattern,
             disabled,
             title,
@@ -125,8 +126,7 @@ const AskGurbaniBotQuestionModal = (props: Props) => {
                 </div>
               </div>
             </form>
-          )
-          }
+          ))}
         </SearchForm>
       </div>
     </Dialog>

--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -79,6 +79,7 @@ export default class SearchForm extends React.PureComponent {
     submitOnChangeOf: PropTypes.arrayOf(
       PropTypes.oneOf(['type', 'source', 'query', 'writer'])
     ),
+    isolateFromLocalStorage: PropTypes.bool,
     onSubmit: (props) => {
       if (
         props.submitOnChangeOf.length !== 0 &&
@@ -97,17 +98,21 @@ export default class SearchForm extends React.PureComponent {
     shouldSubmit: false,
     type:
       this.props.defaultType ||
-      getNumberFromLocalStorage(
-        LOCAL_STORAGE_KEY_FOR_SEARCH_TYPE,
-        DEFAULT_SEARCH_TYPE
-      ),
+      (!this.props.isolateFromLocalStorage &&
+        getNumberFromLocalStorage(
+          LOCAL_STORAGE_KEY_FOR_SEARCH_TYPE,
+          DEFAULT_SEARCH_TYPE
+        )) ||
+      DEFAULT_SEARCH_TYPE,
     source:
       this.props.defaultSource ||
-      localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE) ||
+      (!this.props.isolateFromLocalStorage &&
+        localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE)) ||
       DEFAULT_SEARCH_SOURCE,
     writer:
       this.props.defaultWriter ||
-      localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER) ||
+      (!this.props.isolateFromLocalStorage &&
+        localStorage.getItem(LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER)) ||
       DEFAULT_SEARCH_WRITER,
     writers: DEFAULT_SEARCH_WRITERS,
     isSourceChanged: false,
@@ -118,9 +123,9 @@ export default class SearchForm extends React.PureComponent {
       this.props.defaultAutoDetectGurmukhi !== undefined
         ? this.props.defaultAutoDetectGurmukhi
         : getBooleanFromLocalStorage(
-            LOCAL_STORAGE_KEY_FOR_AUTO_DETECT_GURMUKHI,
-            false
-          ),
+          LOCAL_STORAGE_KEY_FOR_AUTO_DETECT_GURMUKHI,
+          false
+        ),
   };
 
   animatePlaceholder = () => {
@@ -279,10 +284,10 @@ export default class SearchForm extends React.PureComponent {
       typeInt === SEARCH_TYPES.ROMANIZED
         ? ['Enter 4 words minimum.', '(\\w+\\W+){3,}\\w+\\W*']
         : typeInt === SEARCH_TYPES.ANG
-        ? ['Enter numbers only.', '\\d+']
-        : typeInt === SEARCH_TYPES.AUTO_DETECT
-        ? ['Enter 1 characters minimum.', '.{1,}']
-        : ['Enter 2 characters minimum.', '.{2,}'];
+          ? ['Enter numbers only.', '\\d+']
+          : typeInt === SEARCH_TYPES.AUTO_DETECT
+            ? ['Enter 1 characters minimum.', '.{1,}']
+            : ['Enter 2 characters minimum.', '.{2,}'];
 
     const [action, name, inputType] = SearchForm.getFormDetails(typeInt);
     const disabled = !new RegExp(pattern).test(query);
@@ -415,6 +420,19 @@ export default class SearchForm extends React.PureComponent {
     }
   };
 
+  // Centralized localStorage helpers — skips persistence when isolateFromLocalStorage is true 
+  saveToLocalStorage = (key, value) => {
+    if (!this.props.isolateFromLocalStorage) {
+      localStorage.setItem(key, value);
+    }
+  };
+
+  removeFromLocalStorage = (key) => {
+    if (!this.props.isolateFromLocalStorage) {
+      localStorage.removeItem(key);
+    }
+  };
+
   handleSearchSourceChange = ({ target }) => {
     const source = target.value;
     this.setState(
@@ -430,7 +448,7 @@ export default class SearchForm extends React.PureComponent {
           action: ACTIONS.SEARCH_SOURCE,
           label: this.state.source,
         });
-        localStorage.setItem(
+        this.saveToLocalStorage(
           LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE,
           this.state.source
         );
@@ -479,18 +497,18 @@ export default class SearchForm extends React.PureComponent {
           shouldSubmit: isSearchTypeToAngSearchType
             ? false
             : this.props.submitOnChangeOf.includes('type') &&
-              this.state.query !== '',
+            this.state.query !== '',
           displayGurmukhiKeyboard: isShowKeyboard,
         },
         () => {
           this.currentPlaceholderIndex = 0;
 
           clickEvent({ action: ACTIONS.SEARCH_TYPE, label: newSearchType });
-          localStorage.setItem(
+          this.saveToLocalStorage(
             LOCAL_STORAGE_KEY_FOR_SEARCH_TYPE,
             newSearchType
           );
-          localStorage.setItem(
+          this.saveToLocalStorage(
             LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE,
             newSourceType
           );
@@ -515,7 +533,7 @@ export default class SearchForm extends React.PureComponent {
           action: ACTIONS.SEARCH_WRITER,
           label: this.state.writer,
         });
-        localStorage.setItem(
+        this.saveToLocalStorage(
           LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER,
           this.state.writer
         );
@@ -538,11 +556,11 @@ export default class SearchForm extends React.PureComponent {
           this.state.query !== '',
       },
       () => {
-        localStorage.setItem(
+        this.saveToLocalStorage(
           LOCAL_STORAGE_KEY_FOR_SEARCH_SOURCE,
           this.state.source
         );
-        localStorage.removeItem(LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER);
+        this.removeFromLocalStorage(LOCAL_STORAGE_KEY_FOR_SEARCH_WRITER);
       }
     );
   };
@@ -566,7 +584,7 @@ export default class SearchForm extends React.PureComponent {
       () => {
         this.currentPlaceholderIndex = 0;
         // Save to localStorage
-        localStorage.setItem(
+        this.saveToLocalStorage(
           LOCAL_STORAGE_KEY_FOR_AUTO_DETECT_GURMUKHI,
           this.state.autoDetectGurmukhi.toString()
         );

--- a/src/js/components/SearchResults/AskGurbaniBotSearch.tsx
+++ b/src/js/components/SearchResults/AskGurbaniBotSearch.tsx
@@ -3,27 +3,38 @@ import SearchForm from "@/components/SearchForm"
 import SearchIcon from '@/components/Icons/Search';
 import { useHistory } from 'react-router-dom';
 import { toSearchURL } from '@/util';
-import { SEARCH_TYPES } from '@/constants';
+import { SEARCH_TYPES, SOURCES } from '@/constants';
 
 interface Props {
   query: string;
+  source: string;
 }
 
 function AskGurbaniBotSearch(props: Props) {
-  const { query } = props;
+  const { query, source } = props;
   const history = useHistory();
 
-  const handleSubmit = ({ handleFormSubmit, query }: { handleFormSubmit: FormEventHandler, query: string }) => (e: FormEvent) => {
+  const handleSubmit = ({ handleFormSubmit, query, source }: { handleFormSubmit: FormEventHandler, query: string, source: string }) => (e: FormEvent) => {
     e.preventDefault();
     typeof handleFormSubmit === 'function' && handleFormSubmit();
     history.push(toSearchURL({
       query,
       type: SEARCH_TYPES.ASK_A_QUESTION,
       writer: 'all',
-      source: 'all',
+      source,
       offset: ''
     }));
   }
+
+  const handleSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    history.push(toSearchURL({
+      query,
+      type: SEARCH_TYPES.ASK_A_QUESTION,
+      writer: 'all',
+      source: e.target.value,
+      offset: '',
+    }));
+  };
 
   return (
     <div className='ask-gurbani-bot-question-search'>
@@ -48,6 +59,7 @@ function AskGurbaniBotSearch(props: Props) {
             onSubmit={handleSubmit({
               handleFormSubmit: handleFormSubmit,
               query,
+              source,
             })}
           >
             <div className="search-container-wrapper">
@@ -73,6 +85,21 @@ function AskGurbaniBotSearch(props: Props) {
                 <button type="submit" disabled={disabled}>
                   <SearchIcon />
                 </button>
+              </div>
+            </div>
+            <div className="search-options">
+              <div className="search-option">
+                <select
+                  name="source"
+                  value={source}
+                  onChange={handleSourceChange}
+                >
+                  {Object.entries(SOURCES).map(([value, children]) => (
+                    <option key={value} value={value}>
+                      {children}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
           </form>

--- a/src/js/components/SearchResults/SearchResults.js
+++ b/src/js/components/SearchResults/SearchResults.js
@@ -51,7 +51,7 @@ export default class SearchResults extends React.PureComponent {
     return (
       <>
         {askGurbaniBotSearchType && (
-          <AskGurbaniBotSearch query={this.props.q || ''} />
+          <AskGurbaniBotSearch query={this.props.q || ''} source={this.props.source} />
         )}
         {warning}
         <ul className={searchResultsClassName}>


### PR DESCRIPTION
# Feat: Add source filter support in AskGurbaniBot search | Fixes #1828

## Summary

This PR fixes issue [#1828](https://github.com/KhalisFoundation/sttm-web/issues/1828) by adding source selection support to the Ask GurbaniBot modal and ensuring its search state is fully isolated from the main site search (header/SearchForm) state.

---

## Changes

### ✨ feat: Add source selection to AskGurbaniBot search
- Added a source selector (`<select>`) inside `AskGurbaniBotQuestionModal` so users can filter which Gurbani source the bot searches from.
- Updated `AskGurbaniBotSearch` to accept and pass the selected `source` value through to the bot API query.
- Pass the selected `source` from the modal to the `SearchResults` component for the bot search.

### 🔒 feat: Isolate bot search state from main/normal search state
- Introduced an `isolateFromLocalStorage` boolean prop on `SearchForm` to prevent the bot's form state (type, source, writer) from being read from or written to `localStorage`.
- The `AskGurbaniBotQuestionModal` now passes `isolateFromLocalStorage` to its `SearchForm`, keeping the bot's selections completely independent of the main header search.
- Added centralized `saveToLocalStorage` and `removeFromLocalStorage` helper methods inside `SearchForm` that respect the `isolateFromLocalStorage` flag — all existing `localStorage` calls now route through these helpers.
- The main/header search state and local storage preferences are no longer affected when a user interacts with the GurbaniBot search.

---

## Files Changed

| File | Change |
|------|--------|
| `src/js/components/Modals/AskGurbaniBotQuestionModal.tsx` | Added source selector UI; added `isolateFromLocalStorage` prop |
| `src/js/components/SearchResults/AskGurbaniBotSearch.tsx` | Wired `source` prop through to the bot API |
| `src/js/components/SearchForm.js` | Added `isolateFromLocalStorage` prop & localStorage helper methods |
| `src/js/components/Header.js` | Minor formatting/indentation cleanup |

---

* [x] <!-- I --> Passed [sanity tests](http://bit.ly/sttm-sanity-tests).
    - Checked the sanity tests that, for which I was able to find input or elements 
* [x] <!-- I --> Ran `npm test` & fixed newly introduced lint errors.
* [x] <!-- I --> Checked console for errors.
   - I found 3 existing console warning in dev branch, and these are unrelated to changes in this PR, please let me if I should fix those too, by creating a new PR
      - ` Failed prop type: Invalid prop `defaultAutoDetectGurmukhi` of type `boolean` supplied to `SearchForm`, expected `string`.`
      - `Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>. Error Component Stack`  for FloatingActions  
      - `installHook.js:1 Warning: Each child in a list should have a unique "key" prop.` in HomePageIcons
     
## Testing
- [ ] Open the Ask GurbaniBot modal, change the source, and confirm the header search source is **not** affected.
- [ ] Use the GurbaniBot with a specific source and verify results are filtered accordingly.

## Demo Video
https://drive.google.com/file/d/1C_t8AA7QLJFOmsoQiZ5cgFZUWsaOCWsP/view?usp=sharing

### npm test output 
<img width="607" height="159" alt="image" src="https://github.com/user-attachments/assets/8f984c68-eb8a-4e2f-b89b-5e7fbdd01966" />

### Updated UI screenshots

<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/a7e29759-070f-411e-a4eb-510c4f9cac85" />

<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/174fcd99-bb75-4ed4-be97-bb5671e9e233" />
