### PR TITLE
fix: Send bani_type parameter for sundar gutka bani translations

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -118,7 +118,7 @@ app.post('/api/ai-translations', async (req, res) => {
       });
     }
 
-    const { verse_id } = req.body;
+    const { verse_id, bani_type = 'shabad' } = req.body;
     if (!verse_id) {
       return res.status(400).json({
         status: 'error',
@@ -130,7 +130,7 @@ app.post('/api/ai-translations', async (req, res) => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ verse_ids: verse_id }),
+      body: JSON.stringify({ verse_ids: verse_id, bani_type }),
     });
 
     const data = await response.json();

--- a/src/js/components/ShabadContent/ShabadContent.js
+++ b/src/js/components/ShabadContent/ShabadContent.js
@@ -150,13 +150,15 @@ class Shabad extends React.PureComponent {
     }
   }
 
-  fetchAiTranslations = async (verseIds) => {
+  isSundarGutkaRoute = () => this.props.location.pathname.includes('sundar-gutka');
+
+  fetchAiTranslations = async (verseIds, bani_type='shabad') => {
     const response = await fetch('/api/ai-translations', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ verse_id: verseIds })
+      body: JSON.stringify({ verse_id: verseIds, bani_type })
     });
     return response.json();
   };
@@ -203,8 +205,9 @@ class Shabad extends React.PureComponent {
     this.setState({ processedGurbani: gurbani });
 
     const verseIds = gurbani.map((verse) => verse.verseId);
+    const baniType = this.isSundarGutkaRoute() ? 'bani' : 'shabad';
     try {
-      const data = await this.fetchAiTranslations(verseIds);
+      const data = await this.fetchAiTranslations(verseIds, baniType);
 
       const fullTranslation = Object.values(data.verses).filter(obj => obj.text.length > 0);
 
@@ -231,8 +234,9 @@ class Shabad extends React.PureComponent {
     this.setState({ processedPages: pages });
 
     const verseIds = pages.flatMap(({ page }) => page.map((verse) => verse.verseId));
+    const baniType = this.isSundarGutkaRoute() ? 'bani' : 'shabad';
     try {
-      const data = await this.fetchAiTranslations(verseIds);
+      const data = await this.fetchAiTranslations(verseIds, baniType);
 
       const fullTranslation = Object.values(data.verses).filter(obj => obj.text.length > 0);
 
@@ -300,7 +304,7 @@ class Shabad extends React.PureComponent {
       return <Redirect to={`/shabad?id=${getShabadId(info)}`} />;
     }
 
-    const isSundarGutkaRoute = location.pathname.includes('sundar-gutka');
+    const isSundarGutkaRoute = this.isSundarGutkaRoute();
     const isAmritKeertanRoute = location.pathname.includes('amrit-keertan');
     const isParagraphMode = paragraphMode && isSundarGutkaRoute;
     const isShowFooterNav = this.props.hideMeta === false && !isMultiPage;
@@ -359,7 +363,6 @@ class Shabad extends React.PureComponent {
                 {this.state.reviewEligibility.scholarReviewed
                   ? TEXTS.SHABAD_REVIEW.BANNER_BODY_REVIEWED
                   : TEXTS.SHABAD_REVIEW.BANNER_BODY_NOT_REVIEWED}
-                  <a className="review-translations-process-text review-translations-link" href={TEXTS.SHABAD_REVIEW.LEARN_ABOUT_PROCESS_URL}>{TEXTS.SHABAD_REVIEW.LEARN_ABOUT_PROCESS}</a>
               </p>
             </div>
           )}

--- a/src/js/constants/texts.ts
+++ b/src/js/constants/texts.ts
@@ -116,8 +116,6 @@ export const TEXTS = {
     BANNER_HEADING: 'Help improve the new English Translations.',
     BANNER_BODY_NOT_REVIEWED: "These english translations are based on Professor Sahib Singh ji's teeka and translated through a careful AI-assisted process. Your feedback helps us improve clarity, accuracy, and faithfulness to the source.",
     BANNER_BODY_REVIEWED: "These english translations are based on Professor Sahib Singh ji's teeka and are being actively reviewed by Sikh scholars as part of our translation process. You can share feedback to help us improve clarity and accuracy.",
-    LEARN_ABOUT_PROCESS: 'Learn about our process',
-    LEARN_ABOUT_PROCESS_URL: '#',
   },
   SHABAD_RATING: {
     HEADING: 'Review the English Translation of Teeka',


### PR DESCRIPTION
Initially, the input verse_id was used as the key to look up the translation. However, for Sundar Gutka Banis, the received verse_id does not always match the verse_id used for translations.

To handle this, we are sending a bani_type parameter to the server, so it can first map the sundar gutka verse ids with the ids used in translation.