### PR TITLE
fix: false offline screen from unreliable navigator.onLine

### DIFF
--- a/src/js/components/Layout.js
+++ b/src/js/components/Layout.js
@@ -17,6 +17,7 @@ import {
   OFFLINE_COLOR,
 } from '../../../common/constants';
 import { ACTIONS, errorEvent } from '../util/analytics';
+import { verifyOnline } from '../util/verify-online';
 import {
   setOnlineMode,
   closeSettingsPanel,
@@ -273,6 +274,10 @@ class Layout extends React.PureComponent {
     window.addEventListener('offline', this.onOffline);
     window.addEventListener('scroll', this.onScroll, { passive: true });
 
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      verifyOnline().then((reachable) => this.props.setOnlineMode(reachable));
+    }
+
     document.title = this.props.title;
     this.updateTheme();
     addVisraamClass();
@@ -304,7 +309,9 @@ class Layout extends React.PureComponent {
 
   onOnline = () => this.props.setOnlineMode(true);
 
-  onOffline = () => this.props.setOnlineMode(false);
+  onOffline = () => {
+    verifyOnline().then((reachable) => this.props.setOnlineMode(reachable));
+  };
 
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.darkMode !== this.props.darkMode) {

--- a/src/js/features/store/index.js
+++ b/src/js/features/store/index.js
@@ -70,7 +70,7 @@ import {
 } from '../../util';
 
 export const initialState = {
-  online: window !== undefined ? window.navigator.onLine : true,
+  online: true,
   showAdvancedOptions: false,
   showTransliterationOptions: false,
   showTranslationOptions: false,

--- a/src/js/util/__tests__/verify-online.test.ts
+++ b/src/js/util/__tests__/verify-online.test.ts
@@ -1,0 +1,28 @@
+import { verifyOnline } from '../verify-online';
+
+describe('verifyOnline', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it('returns true when the request resolves (reachable)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+    await expect(verifyOnline()).resolves.toBe(true);
+  });
+
+  it('returns false when the request rejects (network error)', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+    await expect(verifyOnline()).resolves.toBe(false);
+  });
+
+  it('issues a no-store same-origin request', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock;
+    await verifyOnline();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/favicon.ico');
+    expect(init).toMatchObject({ method: 'HEAD', cache: 'no-store' });
+  });
+});

--- a/src/js/util/__tests__/verify-online.test.ts
+++ b/src/js/util/__tests__/verify-online.test.ts
@@ -7,22 +7,27 @@ describe('verifyOnline', () => {
     global.fetch = realFetch;
   });
 
-  it('returns true when the request resolves (reachable)', async () => {
+  it('returns true on an ok (2xx) response', async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
     await expect(verifyOnline()).resolves.toBe(true);
   });
 
-  it('returns false when the request rejects (network error)', async () => {
+  it('returns false on a non-ok response (e.g. 500 or a captive portal)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+    await expect(verifyOnline()).resolves.toBe(false);
+  });
+
+  it('returns false when the request rejects (network error / CORS)', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network'));
     await expect(verifyOnline()).resolves.toBe(false);
   });
 
-  it('issues a no-store same-origin request', async () => {
+  it('probes the API health endpoint with a no-store GET', async () => {
     const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
     global.fetch = fetchMock;
     await verifyOnline();
     const [url, init] = fetchMock.mock.calls[0];
-    expect(String(url)).toContain('/favicon.ico');
-    expect(init).toMatchObject({ method: 'HEAD', cache: 'no-store' });
+    expect(String(url)).toContain('/health');
+    expect(init).toMatchObject({ method: 'GET', cache: 'no-store' });
   });
 });

--- a/src/js/util/verify-online.ts
+++ b/src/js/util/verify-online.ts
@@ -1,15 +1,23 @@
+// Probe the app's data API health endpoint (banidb `/health`, which returns
+// `{ ok: true }` with permissive CORS) and trust the actual response, not mere
+// request completion. This confirms the backend the app depends on is really
+// reachable — a captive portal or a same-origin SPA fallback can't fake it.
+const apiBase =
+  (typeof API_URL === 'string' && API_URL) || 'https://api.banidb.com/v2/';
+const HEALTH_URL = `${apiBase}health`;
+
 export async function verifyOnline(timeoutMs = 5000): Promise<boolean> {
   if (typeof window === 'undefined' || typeof fetch === 'undefined') return true;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    await fetch(`/favicon.ico?_=${Date.now()}`, {
-      method: 'HEAD',
+    const response = await fetch(`${HEALTH_URL}?_=${Date.now()}`, {
+      method: 'GET',
       cache: 'no-store',
       signal: controller.signal,
     });
-    return true;
+    return response.ok;
   } catch {
     return false;
   } finally {

--- a/src/js/util/verify-online.ts
+++ b/src/js/util/verify-online.ts
@@ -1,0 +1,18 @@
+export async function verifyOnline(timeoutMs = 5000): Promise<boolean> {
+  if (typeof window === 'undefined' || typeof fetch === 'undefined') return true;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(`/favicon.ico?_=${Date.now()}`, {
+      method: 'HEAD',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Some users (seen in Chrome) get navigator.onLine === false while actually connected, which permanently pinned the app on the offline screen — the online event only fires on a transition, so a false initial value never self-corrected.

- Start optimistic (store online: true) instead of trusting navigator.onLine.
- On mount, only if navigator.onLine reports offline, confirm with a real same-origin request (verify-online util) and set online from the result.
- Verify the offline event the same way before showing the offline screen.