### PR TITLE
fix: stop copy/paste appending [object Object]

### DIFF
--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -33,6 +33,7 @@ import {
   steekMap,
   hindiTranslationMap,
   isShowSehajPaathModeRoute,
+  toPlainShareText,
 } from '@/util';
 import { MahankoshContext } from '@/context';
 import { changeAng, prefetchAng } from './utils';
@@ -135,7 +136,10 @@ class Baani extends React.PureComponent {
         translationMap[language](shabad)
       ),
       ...steekLanguages.map((language) => steekMap[language](shabad)),
-    ].join('\n');
+    ]
+      .map(toPlainShareText)
+      .filter(Boolean)
+      .join('\n');
   };
 
   onCopyClick = (shabad) => () => {

--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -125,17 +125,20 @@ class Baani extends React.PureComponent {
       translationLanguages,
       transliterationLanguages,
       steekLanguages,
+      englishTranslationLanguages = [],
+      hindiTranslationLanguages = [],
     } = this.props;
+
+    const mapped = (map, languages = []) =>
+      languages.map((language) => (map[language] ? map[language](shabad) : ''));
 
     return [
       shabad.verse.unicode,
-      ...transliterationLanguages.map((language) =>
-        transliterationMap[language](shabad)
-      ),
-      ...translationLanguages.map((language) =>
-        translationMap[language](shabad)
-      ),
-      ...steekLanguages.map((language) => steekMap[language](shabad)),
+      ...mapped(transliterationMap, transliterationLanguages),
+      ...mapped(translationMap, translationLanguages),
+      ...mapped(englishTranslationMap, englishTranslationLanguages),
+      ...mapped(hindiTranslationMap, hindiTranslationLanguages),
+      ...mapped(steekMap, steekLanguages),
     ]
       .map(toPlainShareText)
       .filter(Boolean)

--- a/src/js/util/shabad/__tests__/to-plain-share-text.test.ts
+++ b/src/js/util/shabad/__tests__/to-plain-share-text.test.ts
@@ -1,0 +1,35 @@
+import { toPlainShareText } from '../to-plain-share-text';
+
+describe('toPlainShareText()', () => {
+  it('returns trimmed strings', () => {
+    expect(toPlainShareText('  hello  ')).toBe('hello');
+  });
+
+  it('returns empty string for nullish values', () => {
+    expect(toPlainShareText(null)).toBe('');
+    expect(toPlainShareText(undefined)).toBe('');
+  });
+
+  it('prefers unicode on translation/steek objects', () => {
+    expect(
+      toPlainShareText({
+        gurmukhi: 'gurmukhi text',
+        unicode: 'ਯੂਨੀਕੋਡ',
+      })
+    ).toBe('ਯੂਨੀਕੋਡ');
+  });
+
+  it('falls back to gurmukhi when unicode is empty', () => {
+    expect(
+      toPlainShareText({
+        gurmukhi: 'gurmukhi text',
+        unicode: '  ',
+      })
+    ).toBe('gurmukhi text');
+  });
+
+  it('does not stringify leftover objects as [object Object]', () => {
+    expect(toPlainShareText({ foo: 'bar' })).toBe('');
+    expect(toPlainShareText({})).toBe('');
+  });
+});

--- a/src/js/util/shabad/index.ts
+++ b/src/js/util/shabad/index.ts
@@ -2,3 +2,4 @@ export * from './get-shabad-list';
 export * from './multview-formatted-shabad';
 export * from './is-shabad-exist-multiview';
 export * from './get-audio-url';
+export * from './to-plain-share-text';

--- a/src/js/util/shabad/to-plain-share-text.ts
+++ b/src/js/util/shabad/to-plain-share-text.ts
@@ -1,0 +1,32 @@
+/**
+ * Convert a translation/steek/transliteration value into clipboard-safe text.
+ * Punjabi steeks are `{ unicode, gurmukhi }` objects; joining them produces
+ * "[object Object]" (see #1834).
+ */
+export const toPlainShareText = (value: unknown): string => {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (typeof value === 'object') {
+    const record = value as { unicode?: unknown; gurmukhi?: unknown };
+
+    if (typeof record.unicode === 'string' && record.unicode.trim()) {
+      return record.unicode.trim();
+    }
+
+    if (typeof record.gurmukhi === 'string' && record.gurmukhi.trim()) {
+      return record.gurmukhi.trim();
+    }
+  }
+
+  return '';
+};


### PR DESCRIPTION
Fixes #1834

## Problem
Copying a shabad line appended `[object Object]` after the Gurbani and translations.

## Cause
`getShareLine` joined translation/steek values with `\n`. Punjabi steeks (`steekMap`) are `{ unicode, gurmukhi }` objects, not strings. `Array.join` stringifies them as `[object Object]`.

`Steek.tsx` already reads `.unicode`; the copy path did not.

## Change
- Add `toPlainShareText` to pick unicode (fallback gurmukhi) and skip leftover objects
- Use it in `getShareLine` (copy, Facebook share)
- Unit tests for the helper

## Test
1. Open a shabad with Punjabi steek enabled
2. Copy a line via the copy icon
3. Paste — there should be no `[object Object]`