### PR TITLE
fix: prevent Multi-View favourite icon from blanking the page

### DIFF
--- a/src/js/components/FavouriteShabadButton/index.tsx
+++ b/src/js/components/FavouriteShabadButton/index.tsx
@@ -13,7 +13,8 @@ type Props = {
   gurbani: [];
 }
 
-export const FavouriteShabadButton = ({ shabad: { shabadId }, gurbani }: Props) => {
+export const FavouriteShabadButton = ({ shabad, gurbani }: Props) => {
+  const shabadId = shabad && shabad.shabadId
   const { user } = useGetUser<IUser>()
 
   // If user is valid then check for favourite shabads
@@ -24,6 +25,9 @@ export const FavouriteShabadButton = ({ shabad: { shabadId }, gurbani }: Props) 
 
   const handleAddClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    if (!Array.isArray(gurbani) || gurbani.length === 0) {
+      return;
+    }
     dispatch(setGurbaniVerses(gurbani))
     dispatch(setModalOpen('addFavoriteShabad'));
   }

--- a/src/js/components/FavouriteShabadButton/utils/__tests__/get-favourite-verse-options.test.ts
+++ b/src/js/components/FavouriteShabadButton/utils/__tests__/get-favourite-verse-options.test.ts
@@ -1,0 +1,21 @@
+import { getFavouriteVerseOptions } from '../get-favourite-verse-options';
+
+describe('getFavouriteVerseOptions()', () => {
+  it('returns an empty list for missing or invalid verses', () => {
+    expect(getFavouriteVerseOptions(undefined)).toEqual([]);
+    expect(getFavouriteVerseOptions(null)).toEqual([]);
+    expect(getFavouriteVerseOptions([])).toEqual([]);
+    expect(getFavouriteVerseOptions([{}])).toEqual([]);
+  });
+
+  it('maps verses to select options using unicode when present', () => {
+    expect(
+      getFavouriteVerseOptions([
+        {
+          verseId: 10,
+          verse: { unicode: 'ਸਾਰਗ', gurmukhi: 'swrg' },
+        },
+      ])
+    ).toEqual([{ label: 'ਸਾਰਗ', value: 10 }]);
+  });
+});

--- a/src/js/components/FavouriteShabadButton/utils/get-favourite-verse-options.ts
+++ b/src/js/components/FavouriteShabadButton/utils/get-favourite-verse-options.ts
@@ -1,0 +1,20 @@
+type FavouriteVerse = {
+  verseId?: string | number;
+  verse?: {
+    unicode?: string;
+    gurmukhi?: string;
+  };
+};
+
+export const getFavouriteVerseOptions = (gurbaniVerses: unknown) => {
+  if (!Array.isArray(gurbaniVerses)) {
+    return [];
+  }
+
+  return (gurbaniVerses as FavouriteVerse[])
+    .filter((verse) => verse && verse.verse && verse.verseId != null)
+    .map((verse) => ({
+      label: verse.verse.unicode || verse.verse.gurmukhi || String(verse.verseId),
+      value: verse.verseId,
+    }));
+};

--- a/src/js/components/Modals/AddFavouriteShabadModal.tsx
+++ b/src/js/components/Modals/AddFavouriteShabadModal.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Select from 'react-select';
 import { useCreateFavouriteShabad } from '@/components/FavouriteShabadButton/hooks';
+import { getFavouriteVerseOptions } from '@/components/FavouriteShabadButton/utils/get-favourite-verse-options';
 import { setModalOpen } from '@/features/actions';
 import { getShabadId } from '@/util';
 import Dialog from './Dialog';
@@ -12,23 +13,22 @@ interface Props {
 
 const AddFavouriteShabadModal = (props: Props) => {
   const dispatch = useDispatch();
-  const gurbaniVerses = useSelector(state => state.gurbaniVerses);
-  const options = gurbaniVerses.map(gurbani => {
-    return (
-      {
-        label: gurbani.verse.gurmukhi,
-        value: gurbani.verseId,
-      }
-    )
-  });
-
-  const shabadId = getShabadId(gurbaniVerses[0]);
-  const [pankti, setPankti] = useState<string>(options[0].value);
+  const gurbaniVerses = useSelector((state: { gurbaniVerses?: unknown[] }) => state.gurbaniVerses);
+  const options = getFavouriteVerseOptions(gurbaniVerses);
+  const [pankti, setPankti] = useState<string | number | undefined>(options[0] && options[0].value);
   const [comment, setComment] = useState<string>('');
   const create = useCreateFavouriteShabad();
 
+  const selectedVerse = Array.isArray(gurbaniVerses)
+    ? gurbaniVerses.find((verse: { verseId?: string | number }) => verse.verseId === pankti) || gurbaniVerses[0]
+    : undefined;
+  const shabadId = getShabadId(selectedVerse);
+
   const handleShabadSave = (e: FormEvent) => {
     e.preventDefault();
+    if (!shabadId || pankti == null) {
+      return;
+    }
     create.mutate({ shabadId, comment, verseId: pankti });
     dispatch(setModalOpen(''))
   }
@@ -37,17 +37,21 @@ const AddFavouriteShabadModal = (props: Props) => {
     <Dialog isModalOpen={props.isModalOpen} title="Add to Favourites">
       <form method="dialog" onSubmit={handleShabadSave}>
         <label className="title">Select a line to save as the title:
-          <Select
-            options={options}
-            defaultValue={options[0]}
-            className="dropdown"
-            classNamePrefix="react-select"
-            noOptionsMessage={() => null}
-            onChange={(val) => {
-              if (val) {
-                setPankti(val.value)
-              }
-            }} />
+          {options.length === 0 ? (
+            <p>No shabad lines are available to favourite.</p>
+          ) : (
+            <Select
+              options={options}
+              defaultValue={options[0]}
+              className="dropdown"
+              classNamePrefix="react-select"
+              noOptionsMessage={() => null}
+              onChange={(val) => {
+                if (val) {
+                  setPankti(val.value)
+                }
+              }} />
+          )}
 
         </label>
 
@@ -64,7 +68,7 @@ const AddFavouriteShabadModal = (props: Props) => {
           />
         </label>
         <div className="save-btn">
-          <button type="submit" className='btn btn-primary'>Save</button>
+          <button type="submit" className='btn btn-primary' disabled={options.length === 0 || !shabadId}>Save</button>
         </div>
       </form>
     </Dialog>

--- a/src/js/components/ShabadContent/ListOfShabads.js
+++ b/src/js/components/ShabadContent/ListOfShabads.js
@@ -113,9 +113,9 @@ class ListOfShabads extends React.PureComponent {
               media={supportedMedia.filter(m => m !== 'addShabad')}
               onCopyAllClick={handleCopyAll}
               onEmbedClick={handleEmbed}
+              {...this.props.controlProps}
               gurbani={allVerses}
               highlight={Number.isNaN(firstHighlight) ? undefined : firstHighlight}
-              {...this.props.controlProps}
             />
           )}
 

--- a/src/js/components/ShabadContent/ListOfShabads.js
+++ b/src/js/components/ShabadContent/ListOfShabads.js
@@ -94,7 +94,12 @@ class ListOfShabads extends React.PureComponent {
     
     const isShowMetaData = this.props.hideMeta === false;
     const isShowControls = this.props.hideControls === false;
-    const highlightsArray = highlights.split(',')
+    const highlightsArray = (highlights || '').split(',')
+    const allVerses = shabads.reduce(
+      (verses, shabad) => verses.concat(shabad.verses || []),
+      []
+    );
+    const firstHighlight = parseInt(highlightsArray[0], 10);
 
     return (
       <GlobalHotKeys
@@ -108,6 +113,8 @@ class ListOfShabads extends React.PureComponent {
               media={supportedMedia.filter(m => m !== 'addShabad')}
               onCopyAllClick={handleCopyAll}
               onEmbedClick={handleEmbed}
+              gurbani={allVerses}
+              highlight={Number.isNaN(firstHighlight) ? undefined : firstHighlight}
               {...this.props.controlProps}
             />
           )}

--- a/src/js/components/ShareButtons.js
+++ b/src/js/components/ShareButtons.js
@@ -42,14 +42,17 @@ export const supportedMedia = ['favouriteShabad', 'addShabad', 'multiView', 'ran
 
 class ShareButtons extends React.PureComponent {
   constructor(props) {
-    super()
-    this.formattedShabad = {}
+    super(props)
     this.onClickSettings = this.onClickSettings.bind(this);
-    const { highlight, gurbani } = props;
+  }
+
+  getFormattedShabad() {
+    const { highlight, gurbani } = this.props;
     if (!isFalsy(gurbani) && gurbani.length) {
-      const selectedShabad = highlight ? (gurbani?.find(({ verseId }) => verseId === highlight) ?? gurbani[0]) : gurbani[0]
-      this.formattedShabad = multiviewFormattedShabad(selectedShabad)
+      const selectedShabad = highlight ? (gurbani.find(({ verseId }) => verseId === highlight) ?? gurbani[0]) : gurbani[0]
+      return multiviewFormattedShabad(selectedShabad)
     }
+    return {}
   }
   static defaultProps = {
     media: ['whatsapp', 'copy'],
@@ -98,12 +101,9 @@ class ShareButtons extends React.PureComponent {
     toggleSettingsPanel()
   }
 
-  componentWillUnmount() {
-    this.formattedShabad = {}
-  }
-
   render() {
     const { media, onEmbedClick, onCopyAllClick, gurbani } = this.props;
+    const formattedShabad = this.getFormattedShabad();
 
     if (media.length === 0) {
       return null;
@@ -172,8 +172,8 @@ class ShareButtons extends React.PureComponent {
       addShabad: (
         <li key={7}>
           {
-            isKeyExists(this.formattedShabad, 'shabadId')
-            && (<ShabadButtonWrapper shabad={this.formattedShabad} />)
+            isKeyExists(formattedShabad, 'shabadId')
+            && (<ShabadButtonWrapper shabad={formattedShabad} />)
           }
         </li>
       ),
@@ -188,7 +188,7 @@ class ShareButtons extends React.PureComponent {
        favouriteShabad: (
         <li key={9}>
           {
-            <FavouriteShabadButton shabad={this.formattedShabad} gurbani={gurbani} />
+            <FavouriteShabadButton shabad={formattedShabad} gurbani={gurbani} />
           }
         </li>
       ),

--- a/src/js/features/reducers/index.js
+++ b/src/js/features/reducers/index.js
@@ -939,7 +939,7 @@ export default function reducer(state, action) {
     }
 
     case SET_GURBANI_VERSES: {
-      const gurbaniVerses = action.payload;
+      const gurbaniVerses = Array.isArray(action.payload) ? action.payload : [];
       return {
         ...state,
         gurbaniVerses

--- a/src/scss/_sharing.scss
+++ b/src/scss/_sharing.scss
@@ -89,7 +89,9 @@
       margin-left: 0;
     }
 
-    button {
+    button,
+    a,
+    label {
       align-items: center;
       color: #999;
       display: inline-flex;
@@ -97,6 +99,8 @@
       justify-content: center;
 
       &:hover,
+      &:focus,
+      &:active,
       &.active {
         span {
           color: $sttm-orange;


### PR DESCRIPTION
Fixes #1874

## Problem
In Multi-View, tapping the favourite star white-screened the site.

## Cause
`ListOfShabads` included `favouriteShabad` in the toolbar but never passed `gurbani`. `ShareButtons` kept `formattedShabad = {}`. Clicking the star dispatched `undefined` verses. `AddFavouriteShabadModal` then did `gurbaniVerses.map(...)` and `options[0].value` with no guard.

## Change
- Pass flattened verses (and highlight) from Multi-View into `Controls`
- Guard the modal when there are no lines
- Favourite using the selected line's `shabadId`
- Ignore non-array payloads in `SET_GURBANI_VERSES`

## Test
1. Sign in
2. Open Multi-View and display shabads
3. Tap the star — the page must not go blank
4. The add-favourite dialog should list lines from the displayed shabads