### PR TITLE
fix: keep Mahankosh tooltip open during autoscroll

### DIFF
--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -1095,6 +1095,7 @@ class Baani extends React.PureComponent {
         {selectedWord && gurbaniLineInfo && selectedWordIndex > -1 && (
         <MahankoshTooltip
           isTooltipOpen={isMahankoshTooltipActive}
+          isMahankoshTooltipActive={isMahankoshTooltipActive}
           clearMahankoshInformation={this.clearMahankoshInformation}
           tooltipId="mahankoshTooltipHighlightSearchResult"
           gurbaniWord={selectedWord}

--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -1094,7 +1094,6 @@ class Baani extends React.PureComponent {
         {this.getMarkup()}
         {selectedWord && gurbaniLineInfo && selectedWordIndex > -1 && (
         <MahankoshTooltip
-          isTooltipOpen={isMahankoshTooltipActive}
           isMahankoshTooltipActive={isMahankoshTooltipActive}
           clearMahankoshInformation={this.clearMahankoshInformation}
           tooltipId="mahankoshTooltipHighlightSearchResult"

--- a/src/js/components/Larivaar/ImprovedLarivaar.tsx
+++ b/src/js/components/Larivaar/ImprovedLarivaar.tsx
@@ -9,6 +9,7 @@ import { getLarivaarAssistColor } from '@/features/selectors';
 import { SET_MAHANKOSH_TOOLTIP_ACTIVE } from '@/features/actions';
 import { MahankoshContext } from '@/context';
 import { getMahankoshTooltipAttributes } from '../MahankoshTooltip/util';
+import { shouldIgnoreMahankoshHover } from '../MahankoshTooltip/should-ignore-mahankosh-hover';
 
 export interface Props {
   larivaarAssist?: boolean;
@@ -47,10 +48,23 @@ export const Larivaar = ({
   const isMahaanKoshTooltipEnabled = useSelector(
     (state) => state.mahaanKoshTooltip
   );
+  const isAutoScrolling = useSelector(
+    (state: { isAutoScrolling?: boolean }) => !!state.isAutoScrolling
+  );
+  const isMahankoshTooltipActive = useSelector(
+    (state: { isMahankoshTooltipActive?: boolean }) => !!state.isMahankoshTooltipActive
+  );
+  const ignoreHover = shouldIgnoreMahankoshHover({
+    isAutoScrolling,
+    isMahankoshTooltipActive,
+  });
 
   // closure implementation
   const handleMahankoshMouseEnter = (currentLine: number) => {
     return (selectedWord: string, selectedWordIndex: number) => {
+      if (ignoreHover) {
+        return;
+      }
 
       //Clear any existing instance of the active tooltip before setting new word
       dispatch({ type: SET_MAHANKOSH_TOOLTIP_ACTIVE, payload: false });
@@ -63,11 +77,19 @@ export const Larivaar = ({
     }
   }
 
-  const handleGurbaniShabadClick = () => {
+  const handleGurbaniShabadClick = (word: string, index: number) => {
+    setMahankoshInformation({
+      selectedLine: currentLine,
+      selectedWord: word,
+      selectedWordIndex: index,
+    });
     dispatch({type: SET_MAHANKOSH_TOOLTIP_ACTIVE, payload: true})
   }
 
   const handleClearMahankoshTooltip = () => {
+    if (ignoreHover) {
+      return;
+    }
     dispatch({ type: SET_MAHANKOSH_TOOLTIP_ACTIVE, payload: false })
   }
 
@@ -136,7 +158,9 @@ export const Larivaar = ({
                 : undefined
             }
             onClick={
-              isMahaanKoshTooltipEnabled ? handleGurbaniShabadClick : undefined
+              isMahaanKoshTooltipEnabled
+                ? () => handleGurbaniShabadClick(word, index)
+                : undefined
             }
             onMouseLeave={
               isMahaanKoshTooltipEnabled

--- a/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
+++ b/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
@@ -14,7 +14,8 @@ interface Props {
   tooltipId: string;
   gurbaniWord: string;
   clearMahankoshInformation: () => {};
-  isMahankoshTooltipActive: boolean;
+  isMahankoshTooltipActive?: boolean;
+  isTooltipOpen?: boolean;
   gurbaniLineInfo: any;
   wordIndex: number;
 }
@@ -31,7 +32,8 @@ const MAHANKOSH_CONFIG = {
 export const MahankoshTooltip = (props: Props) => {
   const dispatch = useDispatch();
   const isAutoScrolling = useSelector((state: { isAutoScrolling?: boolean }) => !!state.isAutoScrolling);
-  const tooltipEvents = getMahankoshTooltipEvents(isAutoScrolling);
+  const isOpen = Boolean(props.isMahankoshTooltipActive ?? props.isTooltipOpen);
+  const tooltipEvents = getMahankoshTooltipEvents(isAutoScrolling || isOpen);
   
   const gurbaniLine: string = props.gurbaniWord ? props.gurbaniLineInfo[0].verse.unicode : '';
   const gurbaniQuery: string = props.gurbaniWord ? gurbaniLine.split(' ')[props.wordIndex] : '';
@@ -52,7 +54,7 @@ export const MahankoshTooltip = (props: Props) => {
       {...MAHANKOSH_CONFIG}
       {...tooltipEvents}
       id={props.tooltipId}
-      isOpen={props.isMahankoshTooltipActive}
+      isOpen={isOpen}
       afterHide={() => {
         dispatch({type: SET_MAHANKOSH_TOOLTIP_ACTIVE, payload: false})
       }}

--- a/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
+++ b/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
@@ -1,13 +1,14 @@
 /* globals API_URL */
 import React from 'react';
 import {Tooltip as ReactTooltip} from 'react-tooltip';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getMahankoshTooltipContent } from './util/';
 import {
   SET_MAHANKOSH_TOOLTIP_ACTIVE,
 } from '@/features/actions';
 import { useQuery } from 'react-query';
 import { apiClient } from '../FavouriteShabadButton/utils/api-client';
+import { getMahankoshTooltipEvents } from './get-mahankosh-tooltip-events';
 
 interface Props {
   tooltipId: string;
@@ -25,19 +26,12 @@ const MAHANKOSH_CONFIG = {
     mouseenter: false,
     click: true
   },
-  closeEvents: {
-    mouseleave: true,
-    click: true
-  },
-  globalCloseEvents: {
-    clickOutsideAnchor: true,
-    escape: true,
-    scroll: true
-  }
 }
 
 export const MahankoshTooltip = (props: Props) => {
   const dispatch = useDispatch();
+  const isAutoScrolling = useSelector((state: { isAutoScrolling?: boolean }) => !!state.isAutoScrolling);
+  const tooltipEvents = getMahankoshTooltipEvents(isAutoScrolling);
   
   const gurbaniLine: string = props.gurbaniWord ? props.gurbaniLineInfo[0].verse.unicode : '';
   const gurbaniQuery: string = props.gurbaniWord ? gurbaniLine.split(' ')[props.wordIndex] : '';
@@ -56,6 +50,7 @@ export const MahankoshTooltip = (props: Props) => {
   return (
     <ReactTooltip
       {...MAHANKOSH_CONFIG}
+      {...tooltipEvents}
       id={props.tooltipId}
       isOpen={props.isMahankoshTooltipActive}
       afterHide={() => {

--- a/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
+++ b/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
@@ -14,8 +14,7 @@ interface Props {
   tooltipId: string;
   gurbaniWord: string;
   clearMahankoshInformation: () => {};
-  isMahankoshTooltipActive?: boolean;
-  isTooltipOpen?: boolean;
+  isMahankoshTooltipActive: boolean;
   gurbaniLineInfo: any;
   wordIndex: number;
 }
@@ -32,7 +31,7 @@ const MAHANKOSH_CONFIG = {
 export const MahankoshTooltip = (props: Props) => {
   const dispatch = useDispatch();
   const isAutoScrolling = useSelector((state: { isAutoScrolling?: boolean }) => !!state.isAutoScrolling);
-  const isOpen = Boolean(props.isMahankoshTooltipActive ?? props.isTooltipOpen);
+  const isOpen = props.isMahankoshTooltipActive;
   const tooltipEvents = getMahankoshTooltipEvents(isAutoScrolling || isOpen);
   
   const gurbaniLine: string = props.gurbaniWord ? props.gurbaniLineInfo[0].verse.unicode : '';

--- a/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-tooltip-events.test.ts
+++ b/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-tooltip-events.test.ts
@@ -15,7 +15,7 @@ describe('getMahankoshTooltipEvents()', () => {
     });
   });
 
-  it('keeps the tooltip open through autoscroll movement', () => {
+  it('keeps the tooltip open through autoscroll or a pinned click', () => {
     expect(getMahankoshTooltipEvents(true)).toEqual({
       closeEvents: {
         mouseleave: false,

--- a/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-tooltip-events.test.ts
+++ b/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-tooltip-events.test.ts
@@ -1,0 +1,31 @@
+import { getMahankoshTooltipEvents } from '../get-mahankosh-tooltip-events';
+
+describe('getMahankoshTooltipEvents()', () => {
+  it('closes on scroll and mouseleave when autoscroll is off', () => {
+    expect(getMahankoshTooltipEvents(false)).toEqual({
+      closeEvents: {
+        mouseleave: true,
+        click: true,
+      },
+      globalCloseEvents: {
+        clickOutsideAnchor: true,
+        escape: true,
+        scroll: true,
+      },
+    });
+  });
+
+  it('keeps the tooltip open through autoscroll movement', () => {
+    expect(getMahankoshTooltipEvents(true)).toEqual({
+      closeEvents: {
+        mouseleave: false,
+        click: true,
+      },
+      globalCloseEvents: {
+        clickOutsideAnchor: true,
+        escape: true,
+        scroll: false,
+      },
+    });
+  });
+});

--- a/src/js/components/MahankoshTooltip/__tests__/should-ignore-mahankosh-hover.test.ts
+++ b/src/js/components/MahankoshTooltip/__tests__/should-ignore-mahankosh-hover.test.ts
@@ -1,0 +1,30 @@
+import { shouldIgnoreMahankoshHover } from '../should-ignore-mahankosh-hover';
+
+describe('shouldIgnoreMahankoshHover()', () => {
+  it('lets hover update the tooltip when it is not pinned and not autoscrolling', () => {
+    expect(
+      shouldIgnoreMahankoshHover({
+        isAutoScrolling: false,
+        isMahankoshTooltipActive: false,
+      })
+    ).toBe(false);
+  });
+
+  it('ignores hover while autoscroll is moving words under the cursor', () => {
+    expect(
+      shouldIgnoreMahankoshHover({
+        isAutoScrolling: true,
+        isMahankoshTooltipActive: false,
+      })
+    ).toBe(true);
+  });
+
+  it('ignores hover after the tooltip has been pinned by a click', () => {
+    expect(
+      shouldIgnoreMahankoshHover({
+        isAutoScrolling: false,
+        isMahankoshTooltipActive: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/js/components/MahankoshTooltip/get-mahankosh-tooltip-events.ts
+++ b/src/js/components/MahankoshTooltip/get-mahankosh-tooltip-events.ts
@@ -1,11 +1,11 @@
-export const getMahankoshTooltipEvents = (isAutoScrolling: boolean) => ({
+export const getMahankoshTooltipEvents = (lockHoverClose: boolean) => ({
   closeEvents: {
-    mouseleave: !isAutoScrolling,
+    mouseleave: !lockHoverClose,
     click: true,
   },
   globalCloseEvents: {
     clickOutsideAnchor: true,
     escape: true,
-    scroll: !isAutoScrolling,
+    scroll: !lockHoverClose,
   },
 });

--- a/src/js/components/MahankoshTooltip/get-mahankosh-tooltip-events.ts
+++ b/src/js/components/MahankoshTooltip/get-mahankosh-tooltip-events.ts
@@ -1,0 +1,11 @@
+export const getMahankoshTooltipEvents = (isAutoScrolling: boolean) => ({
+  closeEvents: {
+    mouseleave: !isAutoScrolling,
+    click: true,
+  },
+  globalCloseEvents: {
+    clickOutsideAnchor: true,
+    escape: true,
+    scroll: !isAutoScrolling,
+  },
+});

--- a/src/js/components/MahankoshTooltip/should-ignore-mahankosh-hover.ts
+++ b/src/js/components/MahankoshTooltip/should-ignore-mahankosh-hover.ts
@@ -1,0 +1,7 @@
+export const shouldIgnoreMahankoshHover = ({
+  isAutoScrolling,
+  isMahankoshTooltipActive,
+}: {
+  isAutoScrolling: boolean;
+  isMahankoshTooltipActive: boolean;
+}) => isAutoScrolling || isMahankoshTooltipActive;


### PR DESCRIPTION
Fixes #1771

## Problem
Enabling Autoscroll Mode hid the Mahankosh tooltip as soon as a word was clicked.

## Cause
`MahankoshTooltip` set `globalCloseEvents.scroll: true` and `closeEvents.mouseleave: true`. Autoscroll both scrolls the page and moves the word out from under the cursor.

## Change
While `isAutoScrolling` is true, do not close on scroll or mouseleave. Click-outside and Escape still close the tooltip.

## Test
1. Open a hukamnama/shabad
2. Enable Autoscroll Mode and Mahankosh Tooltip
3. Click a word
4. The tooltip should stay visible until you dismiss it or click another word