### PR TITLE
fix: copy Unicode when selecting a GurbaniLipi pankti

### DIFF
--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -33,6 +33,7 @@ import {
   steekMap,
   hindiTranslationMap,
   isShowSehajPaathModeRoute,
+  getUnicodeCopyText,
 } from '@/util';
 import { MahankoshContext } from '@/context';
 import { changeAng, prefetchAng } from './utils';
@@ -215,6 +216,21 @@ class Baani extends React.PureComponent {
 
   removeSelection = () => {
     window.getSelection().removeAllRanges();
+  };
+
+  handleNativeCopy = (e) => {
+    const selection = window.getSelection();
+    const unicodeText = getUnicodeCopyText({
+      unicodeMode: this.props.unicode,
+      selectionAnchorNode: selection && selection.anchorNode,
+    });
+
+    if (!unicodeText || !e.clipboardData) {
+      return;
+    }
+
+    e.preventDefault();
+    e.clipboardData.setData('text/plain', unicodeText);
   };
 
   componentDidMount() {
@@ -1090,6 +1106,7 @@ class Baani extends React.PureComponent {
       <div
         className={`${SHABAD_CONTENT_CLASSNAME} ${centerAlignGurbani || showFullScreen ? ' center-align' : ''
           }`}
+        onCopy={this.handleNativeCopy}
       >
         {this.getMarkup()}
         {selectedWord && gurbaniLineInfo && selectedWordIndex > -1 && (

--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -223,14 +223,26 @@ class Baani extends React.PureComponent {
     const unicodeText = getUnicodeCopyText({
       unicodeMode: this.props.unicode,
       selectionAnchorNode: selection && selection.anchorNode,
+      selectionFocusNode: selection && selection.focusNode,
     });
 
-    if (!unicodeText || !e.clipboardData) {
+    if (!unicodeText) {
       return;
     }
 
-    e.preventDefault();
-    e.clipboardData.setData('text/plain', unicodeText);
+    const clipboard =
+      e.clipboardData || (e.nativeEvent && e.nativeEvent.clipboardData);
+
+    if (clipboard) {
+      e.preventDefault();
+      clipboard.setData('text/plain', unicodeText);
+      return;
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      e.preventDefault();
+      navigator.clipboard.writeText(unicodeText);
+    }
   };
 
   componentDidMount() {

--- a/src/js/components/Baani/Baani.js
+++ b/src/js/components/Baani/Baani.js
@@ -219,11 +219,9 @@ class Baani extends React.PureComponent {
   };
 
   handleNativeCopy = (e) => {
-    const selection = window.getSelection();
     const unicodeText = getUnicodeCopyText({
       unicodeMode: this.props.unicode,
-      selectionAnchorNode: selection && selection.anchorNode,
-      selectionFocusNode: selection && selection.focusNode,
+      selection: window.getSelection(),
     });
 
     if (!unicodeText) {

--- a/src/js/components/BaaniLine.tsx
+++ b/src/js/components/BaaniLine.tsx
@@ -35,6 +35,7 @@ const BaaniLine = ({
   if (isReadingMode) {
     return (
       <div
+        data-unicode-verse={text.unicode}
         className={`gurmukhi gurbani-display gurbani-font ${shouldHighlight ? 'highlight' : ''
           } ${larivaar ? 'larivaar' : ''} ${unicode ? 'unicode' : 'gurlipi-reading-mode'}`}
         style={{ fontSize: `${fontSize}em`, fontFamily: `${fontFamily}`, lineHeight: lineHeight + 0.2 }}
@@ -55,6 +56,7 @@ const BaaniLine = ({
 
   return (
     <div
+      data-unicode-verse={text.unicode}
       className={`gurmukhi gurbani-display gurbani-font ${shouldHighlight ? 'highlight' : ''
         }`}
       style={{ fontSize: `${fontSize}em`, fontFamily: `${fontFamily}`, lineHeight: lineHeight }}

--- a/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
+++ b/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
@@ -34,4 +34,19 @@ describe('getUnicodeCopyText()', () => {
       getUnicodeCopyText({ unicodeMode: false, selectionAnchorNode: node })
     ).toBeNull();
   });
+
+  it('uses the focus node when the anchor is outside GurbaniLipi', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div><div class="translation">Saarang</div>';
+    const gurbani = document.querySelector('.gurlipi').firstChild;
+    const translation = document.querySelector('.translation').firstChild;
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selectionAnchorNode: translation,
+        selectionFocusNode: gurbani,
+      })
+    ).toBe('ਸਾਰਗ');
+  });
 });

--- a/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
+++ b/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
@@ -1,0 +1,37 @@
+import { getUnicodeCopyText } from '../get-unicode-copy-text';
+
+describe('getUnicodeCopyText()', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns null when unicode display mode is on', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div>';
+    const node = document.querySelector('.gurlipi').firstChild;
+
+    expect(
+      getUnicodeCopyText({ unicodeMode: true, selectionAnchorNode: node })
+    ).toBeNull();
+  });
+
+  it('returns unicode when copying from a GurbaniLipi pankti', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ ਮਹਲਾ ੫ ॥"><div class="gurlipi">swrg mhlw 5 ]</div></div>';
+    const node = document.querySelector('.gurlipi').firstChild;
+
+    expect(
+      getUnicodeCopyText({ unicodeMode: false, selectionAnchorNode: node })
+    ).toBe('ਸਾਰਗ ਮਹਲਾ ੫ ॥');
+  });
+
+  it('does not rewrite copies from translations', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="translation">Saarang</div></div>';
+    const node = document.querySelector('.translation').firstChild;
+
+    expect(
+      getUnicodeCopyText({ unicodeMode: false, selectionAnchorNode: node })
+    ).toBeNull();
+  });
+});

--- a/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
+++ b/src/js/util/dom/__tests__/get-unicode-copy-text.test.ts
@@ -1,5 +1,27 @@
 import { getUnicodeCopyText } from '../get-unicode-copy-text';
 
+const textLength = (element: Element): number =>
+  (element.textContent || '').length;
+
+const rangeBetween = (from: Element, to: Element): Range => {
+  const range = document.createRange();
+  range.setStart(from.firstChild as Node, 0);
+  range.setEnd(to.lastChild as Node, textLength(to));
+  return range;
+};
+
+const selectionLike = (
+  range: Range,
+  overrides: Record<string, unknown> = {}
+) => ({
+  anchorNode: range.startContainer,
+  focusNode: range.endContainer,
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+  ...overrides,
+});
+
 describe('getUnicodeCopyText()', () => {
   afterEach(() => {
     document.body.innerHTML = '';
@@ -7,45 +29,112 @@ describe('getUnicodeCopyText()', () => {
 
   it('returns null when unicode display mode is on', () => {
     document.body.innerHTML =
-      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div>';
-    const node = document.querySelector('.gurlipi').firstChild;
-
-    expect(
-      getUnicodeCopyText({ unicodeMode: true, selectionAnchorNode: node })
-    ).toBeNull();
-  });
-
-  it('returns unicode when copying from a GurbaniLipi pankti', () => {
-    document.body.innerHTML =
       '<div data-unicode-verse="ਸਾਰਗ ਮਹਲਾ ੫ ॥"><div class="gurlipi">swrg mhlw 5 ]</div></div>';
-    const node = document.querySelector('.gurlipi').firstChild;
+    const pankti = document.querySelector('.gurlipi') as Element;
+    const selection = selectionLike(rangeBetween(pankti, pankti));
 
-    expect(
-      getUnicodeCopyText({ unicodeMode: false, selectionAnchorNode: node })
-    ).toBe('ਸਾਰਗ ਮਹਲਾ ੫ ॥');
+    expect(getUnicodeCopyText({ unicodeMode: true, selection })).toBeNull();
   });
 
-  it('does not rewrite copies from translations', () => {
+  it('returns null for a collapsed or empty selection', () => {
     document.body.innerHTML =
-      '<div data-unicode-verse="ਸਾਰਗ"><div class="translation">Saarang</div></div>';
-    const node = document.querySelector('.translation').firstChild;
-
-    expect(
-      getUnicodeCopyText({ unicodeMode: false, selectionAnchorNode: node })
-    ).toBeNull();
-  });
-
-  it('uses the focus node when the anchor is outside GurbaniLipi', () => {
-    document.body.innerHTML =
-      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div><div class="translation">Saarang</div>';
-    const gurbani = document.querySelector('.gurlipi').firstChild;
-    const translation = document.querySelector('.translation').firstChild;
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div>';
+    const pankti = document.querySelector('.gurlipi') as Element;
+    const range = rangeBetween(pankti, pankti);
 
     expect(
       getUnicodeCopyText({
         unicodeMode: false,
-        selectionAnchorNode: translation,
-        selectionFocusNode: gurbani,
+        selection: selectionLike(range, { isCollapsed: true }),
+      })
+    ).toBeNull();
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(range, { rangeCount: 0 }),
+      })
+    ).toBeNull();
+    expect(
+      getUnicodeCopyText({ unicodeMode: false, selection: null })
+    ).toBeNull();
+  });
+
+  it('returns the unicode of a selected GurbaniLipi pankti', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ ਮਹਲਾ ੫ ॥"><div class="gurlipi">swrg mhlw 5 ]</div></div>';
+    const pankti = document.querySelector('.gurlipi') as Element;
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(rangeBetween(pankti, pankti)),
+      })
+    ).toBe('ਸਾਰਗ ਮਹਲਾ ੫ ॥');
+  });
+
+  it('supports reading-mode lines', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi-reading-mode">swrg</div></div>';
+    const pankti = document.querySelector(
+      '.gurlipi-reading-mode'
+    ) as Element;
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(rangeBetween(pankti, pankti)),
+      })
+    ).toBe('ਸਾਰਗ');
+  });
+
+  it('joins every selected pankti in order', () => {
+    document.body.innerHTML =
+      '<div id="shabad">' +
+      '<div data-unicode-verse="ਪੰਕਤੀ ਇੱਕ"><div class="gurlipi">pNqI ikk</div></div>' +
+      '<div data-unicode-verse="ਪੰਕਤੀ ਦੋ"><div class="gurlipi">pNqI do</div></div>' +
+      '<div data-unicode-verse="ਪੰਕਤੀ ਤਿੰਨ"><div class="gurlipi">pNqI qinn</div></div>' +
+      '</div>';
+    const gurlipiLines = document.querySelectorAll('.gurlipi');
+    const first = gurlipiLines[0];
+    const third = gurlipiLines[2];
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(rangeBetween(first, third)),
+      })
+    ).toBe('ਪੰਕਤੀ ਇੱਕ\nਪੰਕਤੀ ਦੋ\nਪੰਕਤੀ ਤਿੰਨ');
+  });
+
+  it('does not rewrite copies made entirely outside GurbaniLipi', () => {
+    document.body.innerHTML =
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="translation">Saarang</div></div>';
+    const translation = document.querySelector('.translation') as Element;
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(rangeBetween(translation, translation)),
+      })
+    ).toBeNull();
+  });
+
+  it('falls back to the focus line when the anchor is outside GurbaniLipi', () => {
+    document.body.innerHTML =
+      '<div id="shabad">' +
+      '<div data-unicode-verse="ਸਾਰਗ"><div class="gurlipi">swrg</div></div>' +
+      '<div class="translation">Saarang</div>' +
+      '</div>';
+    const gurbani = document.querySelector('.gurlipi') as Element;
+    const translation = document.querySelector('.translation') as Element;
+    const range = document.createRange();
+    range.setStart(translation.firstChild as Node, 0);
+    range.setEnd(gurbani.firstChild as Node, textLength(gurbani));
+
+    expect(
+      getUnicodeCopyText({
+        unicodeMode: false,
+        selection: selectionLike(range),
       })
     ).toBe('ਸਾਰਗ');
   });

--- a/src/js/util/dom/get-unicode-copy-text.ts
+++ b/src/js/util/dom/get-unicode-copy-text.ts
@@ -1,0 +1,35 @@
+const GURLIPI_SELECTOR = '.gurlipi, .gurlipi-reading-mode';
+
+/**
+ * When Gurbani is shown in ASCII/GurbaniLipi, native copy grabs those
+ * glyphs. Return the pankti's unicode instead (#1802).
+ */
+export const getUnicodeCopyText = ({
+  unicodeMode,
+  selectionAnchorNode,
+}: {
+  unicodeMode: boolean;
+  selectionAnchorNode: Node | null;
+}): string | null => {
+  if (unicodeMode || !selectionAnchorNode) {
+    return null;
+  }
+
+  const element =
+    selectionAnchorNode.nodeType === Node.TEXT_NODE
+      ? selectionAnchorNode.parentElement
+      : (selectionAnchorNode as Element);
+
+  if (!element || typeof element.closest !== 'function') {
+    return null;
+  }
+
+  if (!element.closest(GURLIPI_SELECTOR)) {
+    return null;
+  }
+
+  const line = element.closest('[data-unicode-verse]');
+  const unicode = line && line.getAttribute('data-unicode-verse');
+
+  return unicode || null;
+};

--- a/src/js/util/dom/get-unicode-copy-text.ts
+++ b/src/js/util/dom/get-unicode-copy-text.ts
@@ -1,24 +1,14 @@
 const GURLIPI_SELECTOR = '.gurlipi, .gurlipi-reading-mode';
 
-/**
- * When Gurbani is shown in ASCII/GurbaniLipi, native copy grabs those
- * glyphs. Return the pankti's unicode instead (#1802).
- */
-export const getUnicodeCopyText = ({
-  unicodeMode,
-  selectionAnchorNode,
-}: {
-  unicodeMode: boolean;
-  selectionAnchorNode: Node | null;
-}): string | null => {
-  if (unicodeMode || !selectionAnchorNode) {
+const unicodeFromNode = (node: Node | null): string | null => {
+  if (!node) {
     return null;
   }
 
   const element =
-    selectionAnchorNode.nodeType === Node.TEXT_NODE
-      ? selectionAnchorNode.parentElement
-      : (selectionAnchorNode as Element);
+    node.nodeType === Node.TEXT_NODE
+      ? node.parentElement
+      : (node as Element);
 
   if (!element || typeof element.closest !== 'function') {
     return null;
@@ -32,4 +22,27 @@ export const getUnicodeCopyText = ({
   const unicode = line && line.getAttribute('data-unicode-verse');
 
   return unicode || null;
+};
+
+/**
+ * When Gurbani is shown in ASCII/GurbaniLipi, native copy grabs those
+ * glyphs. Return the pankti's unicode instead (#1802).
+ */
+export const getUnicodeCopyText = ({
+  unicodeMode,
+  selectionAnchorNode,
+  selectionFocusNode = null,
+}: {
+  unicodeMode: boolean;
+  selectionAnchorNode: Node | null;
+  selectionFocusNode?: Node | null;
+}): string | null => {
+  if (unicodeMode) {
+    return null;
+  }
+
+  return (
+    unicodeFromNode(selectionAnchorNode) ||
+    unicodeFromNode(selectionFocusNode)
+  );
 };

--- a/src/js/util/dom/get-unicode-copy-text.ts
+++ b/src/js/util/dom/get-unicode-copy-text.ts
@@ -1,6 +1,14 @@
 const GURLIPI_SELECTOR = '.gurlipi, .gurlipi-reading-mode';
 
-const unicodeFromNode = (node: Node | null): string | null => {
+interface SelectionLike {
+  anchorNode: Node | null;
+  focusNode: Node | null;
+  isCollapsed: boolean;
+  rangeCount: number;
+  getRangeAt(index: number): Range;
+}
+
+const gurbaniLineFromNode = (node: Node | null): Element | null => {
   if (!node) {
     return null;
   }
@@ -18,31 +26,75 @@ const unicodeFromNode = (node: Node | null): string | null => {
     return null;
   }
 
-  const line = element.closest('[data-unicode-verse]');
-  const unicode = line && line.getAttribute('data-unicode-verse');
-
-  return unicode || null;
+  return element.closest('[data-unicode-verse]');
 };
 
 /**
  * When Gurbani is shown in ASCII/GurbaniLipi, native copy grabs those
- * glyphs. Return the pankti's unicode instead (#1802).
+ * glyphs. Return the selected panktis' unicode instead (#1802).
+ *
+ * Returns null (leaving the native copy untouched) when Unicode mode is on,
+ * nothing is visibly selected, or the selection does not start or end inside
+ * a GurbaniLipi line - e.g. copies of translations.
  */
 export const getUnicodeCopyText = ({
   unicodeMode,
-  selectionAnchorNode,
-  selectionFocusNode = null,
+  selection,
 }: {
   unicodeMode: boolean;
-  selectionAnchorNode: Node | null;
-  selectionFocusNode?: Node | null;
+  selection: SelectionLike | null;
 }): string | null => {
-  if (unicodeMode) {
+  if (
+    unicodeMode ||
+    !selection ||
+    selection.isCollapsed ||
+    !selection.rangeCount
+  ) {
     return null;
   }
 
-  return (
-    unicodeFromNode(selectionAnchorNode) ||
-    unicodeFromNode(selectionFocusNode)
-  );
+  const startLine = gurbaniLineFromNode(selection.anchorNode);
+  const endLine = gurbaniLineFromNode(selection.focusNode);
+
+  if (!startLine && !endLine) {
+    return null;
+  }
+
+  let range: Range;
+  try {
+    range = selection.getRangeAt(0);
+  } catch {
+    return null;
+  }
+
+  const ancestor = range.commonAncestorContainer;
+  const scope =
+    ancestor.nodeType === Node.TEXT_NODE
+      ? ancestor.parentElement
+      : (ancestor as Element);
+
+  const selectedLines = scope
+    ? Array.from(scope.querySelectorAll('[data-unicode-verse]')).filter(
+        (line) => range.intersectsNode(line)
+      )
+    : [];
+
+  if (selectedLines.length === 0) {
+    const fallbackLine = startLine || endLine;
+    return fallbackLine
+      ? fallbackLine.getAttribute('data-unicode-verse')
+      : null;
+  }
+
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const line of selectedLines) {
+    const unicode = line.getAttribute('data-unicode-verse');
+    if (unicode && !seen.has(unicode)) {
+      seen.add(unicode);
+      parts.push(unicode);
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n') : null;
 };

--- a/src/js/util/dom/index.ts
+++ b/src/js/util/dom/index.ts
@@ -1,3 +1,4 @@
 export * from './copy-to-clipboard';
+export * from './get-unicode-copy-text';
 export * from './make-selection';
 export * from './update-smart-app-banner-meta-tags';


### PR DESCRIPTION
Fixes #1802

## Problem
The copy-icon copied Unicode. Selecting a pankti and pressing Ctrl/Cmd+C copied ASCII/GurbaniLipi.

## Cause
With Unicode display off, the DOM text is GurbaniLipi. Native copy uses that text.

## Change
- Store each line's unicode on `data-unicode-verse`
- On copy from a `.gurlipi` / `.gurlipi-reading-mode` line, write that unicode to the clipboard
- Leave Unicode-mode copies and translation copies unchanged

## Test
1. Open a shabad with Unicode display **off**
2. Select a pankti and press Ctrl/Cmd+C
3. Paste — it should be Gurmukhi Unicode, not ASCII