### PR TITLE
fix: encode Mahankosh word lookup URL

### DIFF
--- a/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
+++ b/src/js/components/MahankoshTooltip/MahankoshTooltip.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/features/actions';
 import { useQuery } from 'react-query';
 import { apiClient } from '../FavouriteShabadButton/utils/api-client';
+import { getMahankoshWordUrl } from './get-mahankosh-word-url';
 
 interface Props {
   tooltipId: string;
@@ -41,7 +42,9 @@ export const MahankoshTooltip = (props: Props) => {
   
   const gurbaniLine: string = props.gurbaniWord ? props.gurbaniLineInfo[0].verse.unicode : '';
   const gurbaniQuery: string = props.gurbaniWord ? gurbaniLine.split(' ')[props.wordIndex] : '';
-  const url = props.gurbaniWord ? `${API_URL}kosh/word/${gurbaniQuery}` : '';
+  const url = props.gurbaniWord
+    ? getMahankoshWordUrl(API_URL, gurbaniQuery)
+    : '';
 
   const { data: mahankoshExplaination, isLoading: isFetchingMahankoshExplaination, isSuccess } = useQuery({
     queryKey: ['mahakosh-shabad', props.gurbaniWord ],

--- a/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-word-url.test.ts
+++ b/src/js/components/MahankoshTooltip/__tests__/get-mahankosh-word-url.test.ts
@@ -1,0 +1,36 @@
+import { getMahankoshWordUrl } from '../get-mahankosh-word-url';
+
+describe('getMahankoshWordUrl()', () => {
+  const API = '//api.banidb.com/v2/';
+
+  it('builds a plain word lookup', () => {
+    expect(getMahankoshWordUrl(API, 'hukam')).toBe(
+      '//api.banidb.com/v2/kosh/word/hukam'
+    );
+  });
+
+  it('keeps path-breaking characters part of the word', () => {
+    expect(getMahankoshWordUrl(API, 'is/wpY')).toBe(
+      '//api.banidb.com/v2/kosh/word/is%2FwpY'
+    );
+  });
+
+  it('encodes query and fragment characters', () => {
+    expect(getMahankoshWordUrl(API, 'h#k?m')).toBe(
+      '//api.banidb.com/v2/kosh/word/h%23k%3Fm'
+    );
+  });
+
+  it('trims whitespace around the word', () => {
+    expect(getMahankoshWordUrl(API, ' hukam ')).toBe(
+      '//api.banidb.com/v2/kosh/word/hukam'
+    );
+  });
+
+  it('returns an empty url for missing words', () => {
+    expect(getMahankoshWordUrl(API, undefined)).toBe('');
+    expect(getMahankoshWordUrl(API, null)).toBe('');
+    expect(getMahankoshWordUrl(API, '')).toBe('');
+    expect(getMahankoshWordUrl(API, '   ')).toBe('');
+  });
+});

--- a/src/js/components/MahankoshTooltip/get-mahankosh-word-url.ts
+++ b/src/js/components/MahankoshTooltip/get-mahankosh-word-url.ts
@@ -1,0 +1,13 @@
+export const getMahankoshWordUrl = (apiUrl: string, word: unknown): string => {
+  if (typeof word !== 'string') {
+    return '';
+  }
+
+  const query = word.trim();
+
+  if (!query) {
+    return '';
+  }
+
+  return `${apiUrl}kosh/word/${encodeURIComponent(query)}`;
+};


### PR DESCRIPTION
Fixes #1770

## Problem
With the Gurmukhi Akhar encoding enabled, words can contain `/`, `?` or `#`. Inlining such a word into `${API_URL}kosh/word/${word}` unencoded turns it into URL path segments — e.g. `is/wpY` requests `/kosh/word/is/wpY` and 404s.

## Change
- Add `getMahankoshWordUrl()` helper: trims the word, `encodeURIComponent`-encodes it, returns `''` for missing/blank words (matching the existing falsy-url semantics)
- `MahankoshTooltip` builds its lookup URL through the helper

## Note
On current `dev` the queried word is derived from the verse's unicode text (which never contains `/`), so the original repro is likely already mitigated — this makes the lookup robust for any character and guards future regressions.

## Test
1. Settings → encoding: Gurmukhi Akhar
2. Open a shabad, click a word containing `/`
3. The kosh request should hit `/kosh/word/is%2FwpY`-style URLs and show the tooltip

Unit tests added for plain words, path/query/fragment characters, trimming, and blank-word handling.